### PR TITLE
ci: pin version of gh-pages to fix docs publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,7 @@ jobs:
       - run:
           name: Deploy docs to gh-pages
           command: |
-            npx --yes gh-pages \
+            npx --yes gh-pages@3.0.0 \
               --user "ci-build <ci-build@merino.mozilla.org>" \
               --message "[skip ci] Docs updates" \
               --dist workspace/doc


### PR DESCRIPTION
The error we are getting seems to have been [introduced in `gh-pages@3.1.0`](https://github.com/tschaub/gh-pages/issues/354). Pinning to the lower version works in my testing.

To test this, you can either try and run the commands on your own system, or we can merge it and see if it works this time.