### PR TITLE
fix: Provide a root index.html for the docs that directs to the merino crate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,8 @@ jobs:
           name: Build docs
           command: |
             cargo doc --document-private-items --workspace
+            # Add a root index.html that redirects to a specific crate's docs.
+            echo '<meta http-equiv="refresh" content="time; URL=new_url" />' > target/doc/index.html
             mkdir workspace
             cp -r target/doc workspace/
       - persist_to_workspace:


### PR DESCRIPTION
Without this, we get a 404 on the Github Pages site since there is no content at the root. With this, the browser is immediately redirected to a useful page.
