### PR TITLE
test: Re-enable doctest, and mark tests as no_run

### DIFF
--- a/merino-adm/Cargo.toml
+++ b/merino-adm/Cargo.toml
@@ -3,9 +3,6 @@ name = "merino-adm"
 version = "0.1.0"
 edition = "2018"
 
-[lib]
-doctest = false
-
 [dependencies]
 actix-web = "=4.0.0-beta.5"
 serde = "1.0.125"

--- a/merino-suggest/Cargo.toml
+++ b/merino-suggest/Cargo.toml
@@ -3,8 +3,5 @@ name = "merino-suggest"
 version = "0.1.0"
 edition = "2018"
 
-[lib]
-doctest = false
-
 [dependencies]
 serde = { version = "1.0.125", features = ["derive"] }

--- a/merino-web/Cargo.toml
+++ b/merino-web/Cargo.toml
@@ -3,9 +3,6 @@ name = "merino-web"
 version = "0.1.0"
 edition = "2018"
 
-[lib]
-doctest = false
-
 [dependencies]
 actix-web = "=4.0.0-beta.5"
 serde = { version = "1.0.125", features = ["derive"] }

--- a/merino-web/src/lib.rs
+++ b/merino-web/src/lib.rs
@@ -18,32 +18,50 @@ use merino_settings::Settings;
 /// The returned server is a `Future` that must either be `.await`ed, or run it
 /// as a background task using `tokio::spawn`.
 ///
+/// Most of the details from `settings` will be respected, except for those that
+/// go into building the listener (the host and port). If you want to respect the
+/// settings specified in that object, you must include them in the construction
+/// of `listener`.
+///
+/// # Errors
+///
+/// Returns an error if the server cannot be started on the provided listener.
+///
 /// # Examples
 ///
-/// Run the server forever:
+/// Run the server in the foreground. This will only return if there is an error
+/// that causes the server to shut down. This is used to run Merino as a service,
+/// such as in production.
 ///
+/// ```no_run
+/// # tokio_test::block_on(async {
+/// let listener = std::net::TcpListener::bind("127.0.0.1:8080")
+///     .expect("Failed to bind port");
+/// let settings = merino_settings::Settings::load()
+///     .expect("Failed to load settings");
+/// merino_web::run(listener, settings)
+///     .expect("Failed to start server")
+///     .await
+///     .expect("Fatal error while running server");
+/// # })
 /// ```
+///
+/// Run the server as a background task. This will return immediately and process
+/// requests. This is useful for tests.
+///
+/// ```no_run
 /// use std::net::TcpListener;
+/// use merino_settings::Settings;
 ///
-/// tokio_test::block_on(async {
-///     let listener = TcpListener::bind("127.0.0.1:8080")
-///         .expect("Failed to bind port");
-///     merino_web::run(listener)
-///         .expect("Failed to bind address")
-///         .await;
-/// })
-/// ```
-///
-/// Run the server as a background task:
-///
-/// ```
-/// use std::net::TcpListener;
 /// let listener = TcpListener::bind("127.0.0.1:8080")
 ///     .expect("Failed to bind port");
-/// let server = merino_web::run(listener)
-///     .expect("Failed to find address");
+/// let settings = merino_settings::Settings::load()
+///     .expect("Failed to load settings");
+/// let server = merino_web::run(listener, settings)
+///     .expect("Failed to start server");
+///
+/// /// The server can be stopped with `join_handle::abort()`, if needed.
 /// let join_handle = tokio::spawn(server);
-/// // The server can be stopped with join_handle::abort();
 /// ```
 pub fn run(listener: TcpListener, settings: Settings) -> Result<Server, std::io::Error> {
     let num_workers = settings.http.workers;


### PR DESCRIPTION
One of the benefits of rustdoc is that it can compile your examples so that they stay in sync with your code. However, some of our examples cannot be used as doctests, since they would never exit. The correct way to handle this is with the `no_run` "language" on the code examples, not by disabling rust doc entirely.

Shout out to @atsay who noticed that the docs for `merino_web::run` had drifted from the code.
