### PR TITLE
fix(web): assign tracing subscriber to actix-web workers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,6 +1758,7 @@ dependencies = [
  "tokio 1.5.0",
  "tokio-test",
  "tracing",
+ "tracing-futures",
  "tracing-subscriber",
  "viaduct",
  "viaduct-reqwest",
@@ -1793,6 +1794,7 @@ dependencies = [
  "actix-cors",
  "actix-web",
  "anyhow",
+ "futures-util",
  "merino-adm",
  "merino-settings",
  "merino-suggest",
@@ -1803,6 +1805,7 @@ dependencies = [
  "tokio-test",
  "tracing",
  "tracing-actix-web-mozlog",
+ "tracing-futures",
  "uuid",
 ]
 
@@ -3143,20 +3146,22 @@ dependencies = [
 
 [[package]]
 name = "tracing-actix-web-mozlog"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3576de3ac56fd8269018d4934da4675201b7e046e68cf1aaccef6b4f11fc7cc6"
+checksum = "38b0896a51afd1c296ce295580c8c7785bc20ddc26cef6a041b65d5b574afc95"
 dependencies = [
  "actix-http",
  "actix-service",
  "actix-web",
  "chrono",
+ "futures-util",
  "gethostname",
  "serde 1.0.125",
  "serde_json",
  "tracing",
  "tracing-actix-web",
  "tracing-bunyan-formatter",
+ "tracing-futures",
  "tracing-subscriber",
 ]
 

--- a/merino-integration-tests/Cargo.toml
+++ b/merino-integration-tests/Cargo.toml
@@ -20,3 +20,4 @@ viaduct-reqwest = { git = "https://github.com/mozilla/application-services", rev
 tracing = "0.1.26"
 tracing-subscriber = "0.2.18"
 maplit = "1.0.2"
+tracing-futures = "0.2"

--- a/merino-integration-tests/src/logging.rs
+++ b/merino-integration-tests/src/logging.rs
@@ -2,26 +2,30 @@
 //!
 //! This module should be used for general logging behavior. Logging behavior for
 //! specific parts of Merino should be placed in more specific test modules.
-#![cfg(text)]
+#![cfg(test)]
 
-use crate::TestingTools;
+use crate::{merino_test, TestingTools};
 use anyhow::Result;
 
 #[actix_rt::test]
 async fn error_handler_writes_logs() -> Result<()> {
-    let TestingTools {
-        test_client,
-        mut log_watcher,
-        ..
-    } = TestingTools::new(|_| ());
+    merino_test(
+        |_| (),
+        |TestingTools {
+             test_client,
+             mut log_watcher,
+             ..
+         }| async move {
+            test_client
+                .get("/__error__")
+                .send()
+                .await
+                .expect("failed to execute request");
 
-    test_client
-        .get("/__error__")
-        .send()
-        .await
-        .expect("failed to execute request");
+            assert!(log_watcher.has(|msg| msg.field_contains("message", "__error__")));
 
-    assert!(log_watcher.has(|msg| msg.field_contains("message", "__error__")));
-
-    Ok(())
+            Ok(())
+        },
+    )
+    .await
 }

--- a/merino-web/Cargo.toml
+++ b/merino-web/Cargo.toml
@@ -17,4 +17,6 @@ merino-settings = { path = "../merino-settings" }
 uuid = { version = "0.8.2", features = ["v4"] }
 tracing = "0.1.26"
 tokio-test = "0.4.1"
-tracing-actix-web-mozlog = "0.1"
+tracing-actix-web-mozlog = "0.2"
+futures-util = "0.3"
+tracing-futures = "^0.2"

--- a/merino-web/src/lib.rs
+++ b/merino-web/src/lib.rs
@@ -16,7 +16,7 @@ use actix_web::{
 };
 use merino_settings::Settings;
 use std::net::TcpListener;
-use tracing_actix_web_mozlog::MozLogMiddleware;
+use tracing_actix_web_mozlog::MozLog;
 
 /// Run the web server
 ///
@@ -71,10 +71,12 @@ use tracing_actix_web_mozlog::MozLogMiddleware;
 pub fn run(listener: TcpListener, settings: Settings) -> Result<Server, std::io::Error> {
     let num_workers = settings.http.workers;
 
+    let moz_log = MozLog::default();
+
     let mut server = HttpServer::new(move || {
         App::new()
             .data::<Settings>((&settings).clone())
-            .wrap(MozLogMiddleware::new())
+            .wrap(moz_log.clone())
             .wrap(Cors::permissive())
             // The core functionality of Merino
             .service(web::scope("api/v1/suggest").configure(suggest::configure))
@@ -94,7 +96,7 @@ pub fn run(listener: TcpListener, settings: Settings) -> Result<Server, std::io:
     Ok(server)
 }
 
-/// The root view, to provide infomration about what this service is.
+/// The root view, to provide information about what this service is.
 ///
 /// This is intended to be seen by people trying to investigate what this service
 /// is. It should redirect to documentation, if it is available, or provide a

--- a/merino/Cargo.toml
+++ b/merino/Cargo.toml
@@ -15,4 +15,4 @@ viaduct-reqwest = { git = "https://github.com/mozilla/application-services", rev
 tracing-subscriber = { version = "0.2.18", features = ["registry", "env-filter"] }
 tracing = "0.1.26"
 tracing-log = "0.1.2"
-tracing-actix-web-mozlog = "0.1"
+tracing-actix-web-mozlog = "0.2"


### PR DESCRIPTION
Without this, tracing logs produced by actix request handlers and middlewares are not routed to the
correct subscriber, and not available to tests. This works in non-test contexts, but doesn't work
when we don't use a global default subscriber (like in tests).

Given the nature of the fix here, I plan to port this to the common-rs repo. As such, this PR is more of a motivating test case than something I expect to merge.

fix #43
