### PR TITLE
feat: add locking to redis cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2355,6 +2355,7 @@ dependencies = [
  "tokio 1.9.0",
  "tracing",
  "tracing-futures",
+ "uuid",
 ]
 
 [[package]]

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -18,6 +18,7 @@ providers:
 redis_cache:
   url: null
   default_ttl_sec: 900 # 15 minutes
+  default_lock_timeout_sec: 3
 
 memory_cache:
   default_ttl_sec: 900 # 15 minutes

--- a/merino-cache/Cargo.toml
+++ b/merino-cache/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { version = "1", features = ["time"] }
 tracing = { version = "0.1", features = ["async-await"] }
 tracing-futures = "^0.2"
 blake3 = "1"
+uuid = "0.8"
 
 [dev-dependencies]
 http = "^0.2"

--- a/merino-cache/src/redis/mod.rs
+++ b/merino-cache/src/redis/mod.rs
@@ -192,10 +192,7 @@ where
             .add_command(redis::Cmd::set(&pending_key, &lock))
             .add_command(redis::Cmd::expire(
                 &pending_key,
-                self.default_lock_timeout
-                    .as_secs()
-                    .try_into()
-                    .unwrap_or(3),
+                self.default_lock_timeout.as_secs().try_into().unwrap_or(3),
             ))
             .query_async(&mut connection)
             .await

--- a/merino-settings/src/lib.rs
+++ b/merino-settings/src/lib.rs
@@ -154,6 +154,12 @@ pub struct RedisCacheSettings {
     #[serde_as(as = "DurationSeconds")]
     #[serde(rename = "default_ttl_sec")]
     pub default_ttl: Duration,
+
+    /// The default time to try and hold a lock for a response
+    /// from the source on cache refresh/load.
+    #[serde_as(as = "DurationSeconds")]
+    #[serde(rename = "default_lock_timeout_sec")]
+    pub default_lock_timeout: Duration,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
This adds record write locking to redis to prevent multiple threads from
attempting to update a `key` record. This is a VERY simple lock.

Closes #104