### PR TITLE
feat(settings): Make suggestion providers much more configurable at runtime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,7 @@ jobs:
          name: Run Integration tests
          command: |
            docker-compose --version
+           docker-compose -f test-engineering/docker-compose.yml build client
            docker-compose -f test-engineering/docker-compose.yml up --abort-on-container-exit
 
   docker-image-publish:

--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ target
 README.md
 merino-showroom
 !merino-showroom/README.md
+test-engineering

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ README.md
 merino-showroom
 !merino-showroom/README.md
 test-engineering
+config/local.yaml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,6 +681,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-std"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,6 +1554,26 @@ checksum = "6f476e3c4fa6d9a3e0eeabd4f7555a382025ec05194675d72fa1db347e53ae6c"
 dependencies = [
  "lazy_static",
  "log",
+]
+
+[[package]]
+name = "fix-hidden-lifetime-bug"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b7e739f1d47bbc5185391f0b280ef0bd953fa2327d0bf0c619183502923938"
+dependencies = [
+ "fix-hidden-lifetime-bug-proc_macros",
+]
+
+[[package]]
+name = "fix-hidden-lifetime-bug-proc_macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb97774845ef67bfa186b3a39ed2dec87ed70b4932f076ca75392e9c58a6bda1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2433,6 +2464,7 @@ dependencies = [
  "blake3",
  "dashmap",
  "fake",
+ "fix-hidden-lifetime-bug",
  "http",
  "lazy_static",
  "merino-settings",
@@ -2531,6 +2563,7 @@ dependencies = [
  "actix-web 4.0.0-beta.8",
  "actix-web-location",
  "anyhow",
+ "async-recursion",
  "cadence",
  "futures-util",
  "lazy_static",

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,12 +79,7 @@ COPY --from=builder /app/bin /app/bin
 COPY --from=builder /app/version.json /app
 COPY --from=builder /app/config /app/config
 
-ARG HOST=0.0.0.0
-ARG PORT=8080
-ENV MERINO_HTTP__LISTEN="${HOST}:${PORT}"
-
 WORKDIR /app
 USER app
-EXPOSE ${PORT}
 
 CMD ["/app/bin/merino"]

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -4,27 +4,13 @@ http:
   listen: "127.0.0.1:8080"
   workers: null
 
-providers:
-  adm_rs:
-    enabled: false
-    storage_path: "./rs-cache"
-    collection: "quicksuggest"
-    cache: none
-  wiki_fruit:
-    enabled: false
-    cache: none
-  enable_debug_provider: false
+suggestion_providers: {}
 
-redis_cache:
-  url: null
-  default_ttl_sec: 900 # 15 minutes
-  default_lock_timeout_sec: 3
+redis:
+  url: redis://127.0.0.1:6379
 
-memory_cache:
-  default_ttl_sec: 900 # 15 minutes
-  default_lock_timeout_sec: 10
-  cleanup_interval_sec: 300 # 5 minutes
-  max_removed_entries: 100000
+remote_settings:
+  storage_path: "./rs-cache"
 
 logging:
   levels: [INFO]

--- a/config/ci.yaml
+++ b/config/ci.yaml
@@ -1,0 +1,26 @@
+# Enable additional features to debug the application
+debug: true
+
+http:
+  # The host and port Merino listens on
+  listen: "0.0.0.0:8000"
+  # Limit the number of HTTP workers
+  workers: 1
+
+location:
+  # The location of the maxmind database to use to determine IP location
+  maxmind_database: "/tmp/dev/GeoLite2-City-Test.mmdb"
+
+logging:
+  # Print logs in a verbose, formatted format
+  format: pretty
+  # The minimum level that logs should be reported at
+  levels: ["DEBUG"]
+
+# The suggestion providers to enable
+suggestion_providers:
+  test:
+    type: "wiki_fruit"
+
+sentry:
+  mode: "disabled"

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -3,14 +3,14 @@ debug: true
 logging:
   format: pretty
 
-providers:
-  adm_rs:
-    enabled: true
-    storage_path: "./rs-cache"
+suggestion_providers:
+  adm:
+    type: remote_settings
     collection: "quicksuggest"
   wiki_fruit:
-    enabled: true
-  enable_debug_provider: true
+    type: wiki_fruit
+  debug:
+    type: debug
 
 location:
   maxmind_database: "./dev/GeoLite2-City-Test.mmdb"

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -3,10 +3,9 @@ http:
   # parallel
   listen: 127.0.0.1:0
 
-redis_cache:
+redis:
   # This is the docker-compose provided server, in ./dev/.
   url: redis://localhost:6379
-  default_ttl_sec: 600
 
 metrics:
   sink_address: "0.0.0.0:0"

--- a/dev/wait-for-it.sh
+++ b/dev/wait-for-it.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Use this script to test if a given TCP host/port are available
+
+# From https://github.com/vishnubob/wait-for-it/blob/81b1373f17855a4dc21156cfe1694c31d7d1792e/wait-for-it.sh
+
+# The MIT License (MIT)
+# Copyright (c) 2016 Giles Hall
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of
+# this software and associated documentation files (the "Software"), to deal in
+# the Software without restriction, including without limitation the rights to
+# use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# of the Software, and to permit persons to whom the Software is furnished to do
+# so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+WAITFORIT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo -n > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# Check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+
+WAITFORIT_BUSYTIMEFLAG=""
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+    WAITFORIT_ISBUSY=1
+    # Check if busybox timeout uses -t flag
+    # (recent Alpine versions don't support -t anymore)
+    if timeout &>/dev/stdout | grep -q -e '-t '; then
+        WAITFORIT_BUSYTIMEFLAG="-t"
+    fi
+else
+    WAITFORIT_ISBUSY=0
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi
+ 

--- a/merino-adm/src/remote_settings.rs
+++ b/merino-adm/src/remote_settings.rs
@@ -14,7 +14,7 @@ use remote_settings_client::client::FileStorage;
 use serde::Deserialize;
 use serde_json::Value;
 use serde_with::{serde_as, DisplayFromStr};
-use std::{borrow::Cow, collections::HashMap, convert::TryFrom, sync::Arc};
+use std::{collections::HashMap, convert::TryFrom, sync::Arc};
 use tokio::sync::OnceCell;
 
 lazy_static! {
@@ -222,17 +222,17 @@ impl RemoteSettingsSuggester {
 }
 
 #[async_trait]
-impl<'a> SuggestionProvider<'a> for RemoteSettingsSuggester {
-    fn name(&self) -> std::borrow::Cow<'a, str> {
-        Cow::from("AdmRemoteSettings")
+impl SuggestionProvider for RemoteSettingsSuggester {
+    fn name(&self) -> String {
+        "AdmRemoteSettings".into()
     }
 
     async fn suggest(
         &self,
-        request: SuggestionRequest<'a>,
+        request: SuggestionRequest,
     ) -> Result<SuggestionResponse, SuggestError> {
         let suggestions = if request.accepts_english {
-            match self.suggestions.get(request.query.as_ref()) {
+            match self.suggestions.get(&request.query) {
                 Some(suggestion) => vec![suggestion.as_ref().clone()],
                 _ => vec![],
             }

--- a/merino-cache/Cargo.toml
+++ b/merino-cache/Cargo.toml
@@ -19,6 +19,7 @@ tracing = { version = "0.1", features = ["async-await"] }
 tracing-futures = "^0.2"
 blake3 = "1"
 uuid = "0.8"
+fix-hidden-lifetime-bug = "0.2.4"
 
 [dev-dependencies]
 http = "^0.2"

--- a/merino-cache/src/memory.rs
+++ b/merino-cache/src/memory.rs
@@ -16,7 +16,6 @@ use merino_suggest::{
     CacheStatus, Suggestion, SuggestionProvider, SuggestionRequest, SuggestionResponse,
 };
 use std::{
-    borrow::Cow,
     collections::HashMap,
     fmt::Debug,
     hash::Hash,
@@ -82,9 +81,9 @@ impl LOCK_TABLE {
 }
 
 /// A in-memory cache for suggestions.
-pub struct Suggester<S> {
+pub struct Suggester {
     /// The suggester to query on cache-miss.
-    inner: S,
+    inner: Box<dyn SuggestionProvider>,
 
     /// The cached items.
     items: Arc<DedupedMap<String, Instant, Vec<Suggestion>>>,
@@ -96,9 +95,9 @@ pub struct Suggester<S> {
     default_lock_timeout: Duration,
 }
 
-impl<S> Suggester<S> {
+impl Suggester {
     /// Create a in-memory suggestion cache from settings that wraps `provider`.
-    pub fn new_boxed(settings: &Settings, provider: S) -> Box<Self> {
+    pub fn new_boxed(settings: &Settings, provider: Box<dyn SuggestionProvider>) -> Box<Self> {
         let items = Arc::new(DedupedMap::new());
 
         {
@@ -171,19 +170,14 @@ impl<S> Suggester<S> {
 }
 
 #[async_trait]
-impl<'a, S> SuggestionProvider<'a> for Suggester<S>
-where
-    S: for<'b> SuggestionProvider<'b> + Send + Sync,
-{
-    fn name(&self) -> Cow<'a, str> {
-        /// The name of the provider.
-        static NAME: &str = "in-memory-cache";
-        Cow::from(NAME)
+impl SuggestionProvider for Suggester {
+    fn name(&self) -> String {
+        "in-memory-cache".into()
     }
 
     async fn suggest(
         &self,
-        query: SuggestionRequest<'a>,
+        query: SuggestionRequest,
     ) -> Result<SuggestionResponse, merino_suggest::SuggestError> {
         let now = Instant::now();
         let key = query.cache_key().to_string();
@@ -247,7 +241,7 @@ mod tests {
     use super::{Suggester, LOCK_TABLE};
     use crate::deduped_map::DedupedMap;
     use fake::{Fake, Faker};
-    use merino_suggest::{Suggestion, WikiFruit};
+    use merino_suggest::Suggestion;
     use std::{
         sync::Arc,
         time::{Duration, Instant},
@@ -273,8 +267,7 @@ mod tests {
         assert!(cache.contains_key(&"current".to_owned()));
         assert!(cache.contains_key(&"expired".to_owned()));
 
-        // `WikiFruit` here is simply to fulfill the generic argument. It isn't used.
-        Suggester::<WikiFruit>::remove_expired_entries(&cache);
+        Suggester::remove_expired_entries(&cache);
 
         assert_eq!(cache.len_storage(), 1);
         assert_eq!(cache.len_pointers(), 1);

--- a/merino-integration-tests/src/suggest.rs
+++ b/merino-integration-tests/src/suggest.rs
@@ -1,18 +1,18 @@
 //! Tests Merino's ability to make basic suggestions.
 #![cfg(test)]
 
-use std::collections::HashSet;
-
 use crate::{merino_test_macro, TestingTools};
 use anyhow::Result;
 use httpmock::{Method::GET, MockServer};
+use merino_settings::providers::{RemoteSettingsConfig, SuggestionProviderConfig};
 use reqwest::StatusCode;
 use serde_json::json;
+use std::collections::HashSet;
 
 #[merino_test_macro(|settings| {
     // Wiki fruit is only enabled when debug is true.
     settings.debug = true;
-    settings.providers.wiki_fruit.enabled = true;
+    settings.suggestion_providers.insert("wiki_fruit".to_string(), SuggestionProviderConfig::WikiFruit);
 })]
 async fn suggest_wikifruit_works(TestingTools { test_client, .. }: TestingTools) -> Result<()> {
     let response = test_client.get("/api/v1/suggest?q=apple").send().await?;
@@ -30,7 +30,7 @@ async fn suggest_wikifruit_works(TestingTools { test_client, .. }: TestingTools)
 #[merino_test_macro(|settings| {
     // Wiki fruit is only enabled when debug is true.
     settings.debug = true;
-    settings.providers.wiki_fruit.enabled = true;
+    settings.suggestion_providers.insert("wiki_fruit".to_string(), SuggestionProviderConfig::WikiFruit);
 })]
 async fn test_expected_fields(TestingTools { test_client, .. }: TestingTools) -> Result<()> {
     let response = test_client.get("/api/v1/suggest?q=apple").send().await?;
@@ -64,7 +64,12 @@ async fn test_expected_fields(TestingTools { test_client, .. }: TestingTools) ->
     Ok(())
 }
 
-#[merino_test_macro(|settings| settings.providers.adm_rs.enabled = true )]
+#[merino_test_macro(|settings| {
+    settings.suggestion_providers.insert(
+        "adm".to_string(),
+        SuggestionProviderConfig::RemoteSettings(RemoteSettingsConfig::default())
+    );
+})]
 async fn suggest_adm_rs_works(
     TestingTools {
         test_client,
@@ -117,7 +122,7 @@ fn setup_empty_remote_settings_collection(server: MockServer) {
 #[merino_test_macro(|settings| {
     // Wiki fruit is only enabled when debug is true.
     settings.debug = true;
-    settings.providers.wiki_fruit.enabled = true;
+    settings.suggestion_providers.insert("wiki_fruit".to_string(), SuggestionProviderConfig::WikiFruit);
 })]
 async fn suggest_records_suggestion_metrics(
     TestingTools {

--- a/merino-settings/src/lib.rs
+++ b/merino-settings/src/lib.rs
@@ -29,6 +29,7 @@
 //! `config/local.toml`.
 
 mod logging;
+pub mod providers;
 mod redis;
 
 pub use logging::{LogFormat, LoggingSettings};
@@ -38,8 +39,10 @@ use config::{Config, Environment, File};
 use http::Uri;
 use sentry::internals::Dsn;
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, DisplayFromStr, DurationSeconds};
-use std::{net::SocketAddr, path::PathBuf, str::FromStr, time::Duration};
+use serde_with::{serde_as, DisplayFromStr};
+use std::{collections::HashMap, net::SocketAddr, path::PathBuf, str::FromStr};
+
+use crate::providers::SuggestionProviderConfig;
 
 /// Top level settings object for Merino.
 #[serde_as]
@@ -56,9 +59,8 @@ pub struct Settings {
     /// Settings for the HTTP server.
     pub http: HttpSettings,
 
-    /// Configuration for providers. Each provider has a `enabled` field that
-    /// will control if it is active at all on the server.
-    pub providers: SuggestionProviderSettings,
+    /// Providers to use to generate suggestions
+    pub suggestion_providers: HashMap<String, SuggestionProviderConfig>,
 
     /// Logging settings.
     pub logging: LoggingSettings,
@@ -74,16 +76,14 @@ pub struct Settings {
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub public_documentation: Option<Uri>,
 
-    /// Settings for the Redis-based suggestion cache. This can be used by any
-    /// provider by setting the provider's cache type to "redis".
-    pub redis_cache: RedisCacheSettings,
+    /// Settings for connecting to Redis.
+    pub redis: RedisSettings,
+
+    /// Settings for connecting to Remote Settings.
+    pub remote_settings: RemoteSettingsGlobalSettings,
 
     /// Settings to use when determining the location associated with requests.
     pub location: LocationSettings,
-
-    /// Settings for the in-memory suggestion cache. This can be used by any
-    /// provider by setting the provider's cache type to "memory".
-    pub memory_cache: MemoryCacheSettings,
 }
 
 /// Settings for the HTTP server.
@@ -95,21 +95,6 @@ pub struct HttpSettings {
     /// The number of workers to use. Optional. If no value is provided, the
     /// number of logical cores will be used.
     pub workers: Option<usize>,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-/// Settings for individual providers. Each provider should have an `enabled` field.
-pub struct SuggestionProviderSettings {
-    /// Settings for the Ad Marketplace Remote Settings-based provider.
-    pub adm_rs: AdmRsSettings,
-
-    /// Settings for the development provider.
-    pub wiki_fruit: WikiFruitSettings,
-
-    /// Whether to enable the debug provider. This is on by default in
-    /// development environments. It is an error to enable this if the `debug`
-    /// setting isn't set to true.
-    pub enable_debug_provider: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -150,20 +135,21 @@ pub struct WikiFruitSettings {
 
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct RedisCacheSettings {
+pub struct RedisSettings {
     /// The URL to connect to Redis at. Example: `redis://127.0.0.1/db`
-    #[serde_as(as = "Option<crate::redis::AsConnectionInfo>")]
-    pub url: Option<::redis::ConnectionInfo>,
+    #[serde_as(as = "crate::redis::AsConnectionInfo")]
+    pub url: ::redis::ConnectionInfo,
+}
 
-    #[serde_as(as = "DurationSeconds")]
-    #[serde(rename = "default_ttl_sec")]
-    pub default_ttl: Duration,
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RemoteSettingsGlobalSettings {
+    /// The path, relative or absolute, to where to store Remote Settings data.
+    pub storage_path: PathBuf,
 
-    /// The default time to try and hold a lock for a response
-    /// from the source on cache refresh/load.
-    #[serde_as(as = "DurationSeconds")]
-    #[serde(rename = "default_lock_timeout_sec")]
-    pub default_lock_timeout: Duration,
+    /// The server to sync from. If no value is provided, a default is provided
+    /// by the remote settings client.
+    pub server: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -171,32 +157,6 @@ pub struct LocationSettings {
     /// The location of the maxmind database to use to determine IP location. If
     /// not specified, location information will not be calculated.
     pub maxmind_database: Option<PathBuf>,
-}
-
-#[serde_as]
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct MemoryCacheSettings {
-    /// The default TTL to assign to a cache entry if the underlying provider does not provide one.
-    #[serde_as(as = "DurationSeconds")]
-    #[serde(rename = "default_ttl_sec")]
-    pub default_ttl: Duration,
-
-    /// The cleanup task will be run with a period equal to this setting. Any
-    /// expired entries will be removed from the cache.
-    #[serde_as(as = "DurationSeconds")]
-    #[serde(rename = "cleanup_interval_sec")]
-    pub cleanup_interval: Duration,
-
-    /// While running the cleanup task, at most this many entries will be removed
-    /// before cancelling the task. This should be used to limit the maximum
-    /// amount of time the cleanup task takes.
-    pub max_removed_entries: usize,
-
-    /// The default TTL for in-memory locks to prevent multiple update requests from
-    /// being fired at providers at the same time.
-    #[serde_as(as = "DurationSeconds")]
-    #[serde(rename = "default_lock_timeout_sec")]
-    pub default_lock_timeout: Duration,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/merino-settings/src/providers.rs
+++ b/merino-settings/src/providers.rs
@@ -1,0 +1,132 @@
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DurationSeconds};
+use std::time::Duration;
+
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SuggestionProviderConfig {
+    RemoteSettings(RemoteSettingsConfig),
+    MemoryCache(MemoryCacheConfig),
+    RedisCache(RedisCacheConfig),
+    Multiplexer(MultiplexerConfig),
+    Debug,
+    WikiFruit,
+    Null,
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+#[serde(default)]
+pub struct MultiplexerConfig {
+    /// The multiplexed providers.
+    pub providers: Vec<SuggestionProviderConfig>,
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
+pub struct RedisCacheConfig {
+    // /// The URL to connect to Redis at. Example: `redis://127.0.0.1/db`
+    // #[serde_as(as = "crate::redis::AsConnectionInfo")]
+    // pub url: redis::ConnectionInfo,
+    /// The default time a cache entry will be valid for, if not specified by
+    /// the inner provider.
+    #[serde_as(as = "DurationSeconds")]
+    #[serde(rename = "default_ttl_sec")]
+    pub default_ttl: Duration,
+
+    /// The default time to try and hold a lock for a response
+    /// from the source on cache refresh/load.
+    #[serde_as(as = "DurationSeconds")]
+    #[serde(rename = "default_lock_timeout_sec")]
+    pub default_lock_timeout: Duration,
+
+    /// The cached provider.
+    pub inner: Box<SuggestionProviderConfig>,
+}
+
+impl RedisCacheConfig {
+    pub fn with_inner(inner: SuggestionProviderConfig) -> Self {
+        Self {
+            inner: Box::new(inner),
+            ..Default::default()
+        }
+    }
+}
+
+impl Default for RedisCacheConfig {
+    fn default() -> Self {
+        Self {
+            default_ttl: Duration::from_secs(900), // 15 minutes
+            default_lock_timeout: Duration::from_secs(3),
+            inner: Box::new(SuggestionProviderConfig::Null),
+        }
+    }
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MemoryCacheConfig {
+    /// The default TTL to assign to a cache entry if the underlying provider does not provide one.
+    #[serde_as(as = "DurationSeconds")]
+    #[serde(rename = "default_ttl_sec")]
+    pub default_ttl: Duration,
+
+    /// The cleanup task will be run with a period equal to this setting. Any
+    /// expired entries will be removed from the cache.
+    #[serde_as(as = "DurationSeconds")]
+    #[serde(rename = "cleanup_interval_sec")]
+    pub cleanup_interval: Duration,
+
+    /// While running the cleanup task, at most this many entries will be removed
+    /// before cancelling the task. This should be used to limit the maximum
+    /// amount of time the cleanup task takes.
+    pub max_removed_entries: usize,
+
+    /// The default TTL for in-memory locks to prevent multiple update requests from
+    /// being fired at providers at the same time.
+    #[serde_as(as = "DurationSeconds")]
+    #[serde(rename = "default_lock_timeout_sec")]
+    pub default_lock_timeout: Duration,
+
+    /// The cached provider.
+    pub inner: Box<SuggestionProviderConfig>,
+}
+
+impl MemoryCacheConfig {
+    pub fn with_inner(inner: SuggestionProviderConfig) -> Self {
+        Self {
+            inner: Box::new(inner),
+            ..Default::default()
+        }
+    }
+}
+
+impl Default for MemoryCacheConfig {
+    fn default() -> Self {
+        Self {
+            default_ttl: Duration::from_secs(900),
+            cleanup_interval: Duration::from_secs(300),
+            max_removed_entries: 100_000,
+            default_lock_timeout: Duration::from_secs(10),
+            inner: Box::new(SuggestionProviderConfig::Null),
+        }
+    }
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
+pub struct RemoteSettingsConfig {
+    /// The collection to sync form.
+    pub collection: String,
+}
+
+impl Default for RemoteSettingsConfig {
+    fn default() -> Self {
+        Self {
+            collection: "quicksuggest".to_string(),
+        }
+    }
+}

--- a/merino-suggest/src/debug.rs
+++ b/merino-suggest/src/debug.rs
@@ -2,7 +2,7 @@
 //!
 //! It is meant to be used in development and testing.
 
-use std::{borrow::Cow, marker::PhantomData};
+use std::marker::PhantomData;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -36,14 +36,14 @@ impl DebugProvider {
 }
 
 #[async_trait]
-impl<'a> SuggestionProvider<'a> for DebugProvider {
-    fn name(&self) -> Cow<'a, str> {
-        Cow::from("DebugProvider")
+impl SuggestionProvider for DebugProvider {
+    fn name(&self) -> String {
+        "DebugProvider".to_string()
     }
 
     async fn suggest(
         &self,
-        request: SuggestionRequest<'a>,
+        request: SuggestionRequest,
     ) -> Result<SuggestionResponse, SuggestError> {
         let json: String = serde_json::to_string(&request).map_err(SuggestError::Serialization)?;
 

--- a/merino-suggest/src/lib.rs
+++ b/merino-suggest/src/lib.rs
@@ -8,7 +8,6 @@ mod domain;
 mod multi;
 mod wikifruit;
 
-use std::borrow::Cow;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::ops::Range;
@@ -38,19 +37,19 @@ pub const FIREFOX_TEST_VERSIONS: Range<u32> = 70..95;
 
 /// A request for suggestions.
 #[derive(Debug, Clone, Hash, Serialize)]
-pub struct SuggestionRequest<'a> {
+pub struct SuggestionRequest {
     /// The text typed by the user.
-    pub query: Cow<'a, str>,
+    pub query: String,
 
     /// Whether or not the request indicated support for English.
     pub accepts_english: bool,
 
     /// Country in ISO 3166-1 alpha-2 format, such as "MX" for Mexico or "IT" for Italy.
-    pub country: Option<Cow<'a, str>>,
+    pub country: Option<String>,
 
     /// Region/region (e.g. a US state) in ISO 3166-2 format, such as "QC"
     /// for Quebec (with country = "CA") or "TX" for Texas (with country = "US").
-    pub region: Option<Cow<'a, str>>,
+    pub region: Option<String>,
 
     /// The Designated Market Area code, as defined by [Nielsen]. Only defined in the US.
     ///
@@ -58,25 +57,22 @@ pub struct SuggestionRequest<'a> {
     pub dma: Option<u16>,
 
     /// City, listed by name such as "Portland" or "Berlin".
-    pub city: Option<Cow<'a, str>>,
+    pub city: Option<String>,
 
     /// The user agent of the request, including OS family, device form factor, and major Firefox
     /// version number.
     pub device_info: DeviceInfo,
 }
 
-impl<'a, F> fake::Dummy<F> for SuggestionRequest<'a> {
+impl<'a, F> fake::Dummy<F> for SuggestionRequest {
     fn dummy_with_rng<R: rand::Rng + ?Sized>(_config: &F, rng: &mut R) -> Self {
         Self {
-            query: Words(1..10)
-                .fake_with_rng::<Vec<String>, R>(rng)
-                .join(" ")
-                .into(),
+            query: Words(1..10).fake_with_rng::<Vec<String>, R>(rng).join(" "),
             accepts_english: Faker.fake(),
-            country: Some(CountryCode().fake::<String>().into()),
-            region: Some(StateAbbr().fake::<String>().into()),
+            country: Some(CountryCode().fake::<String>()),
+            region: Some(StateAbbr().fake::<String>()),
             dma: Some(rng.gen_range(100_u16..1000)),
-            city: Some(CityName().fake::<String>().into()),
+            city: Some(CityName().fake::<String>()),
             device_info: Faker.fake(),
         }
     }
@@ -240,15 +236,12 @@ fn fake_example_url<R: rand::Rng + ?Sized>(rng: &mut R) -> Uri {
 
 /// A backend that can provide suggestions for queries.
 #[async_trait]
-pub trait SuggestionProvider<'a> {
+pub trait SuggestionProvider: Send + Sync {
     /// An operator-visible name for this suggestion provider.
-    fn name(&self) -> Cow<'a, str>;
+    fn name(&self) -> String;
 
     /// Provide suggested results for `query`.
-    async fn suggest(
-        &self,
-        query: SuggestionRequest<'a>,
-    ) -> Result<SuggestionResponse, SuggestError>;
+    async fn suggest(&self, query: SuggestionRequest) -> Result<SuggestionResponse, SuggestError>;
 }
 
 /// Errors that may occur while setting up the provider.

--- a/merino-suggest/src/lib.rs
+++ b/merino-suggest/src/lib.rs
@@ -244,6 +244,20 @@ pub trait SuggestionProvider: Send + Sync {
     async fn suggest(&self, query: SuggestionRequest) -> Result<SuggestionResponse, SuggestError>;
 }
 
+/// A provider that never provides any suggestions
+pub struct NullProvider;
+
+#[async_trait]
+impl SuggestionProvider for NullProvider {
+    fn name(&self) -> String {
+        "NullProvider".into()
+    }
+
+    async fn suggest(&self, _query: SuggestionRequest) -> Result<SuggestionResponse, SuggestError> {
+        Ok(SuggestionResponse::new(vec![]))
+    }
+}
+
 /// Errors that may occur while setting up the provider.
 #[derive(Debug, Error)]
 #[allow(missing_docs, clippy::missing_docs_in_private_items)]

--- a/merino-suggest/src/wikifruit.rs
+++ b/merino-suggest/src/wikifruit.rs
@@ -3,7 +3,7 @@
 //! It is useful in that it is fully self contained and very simple. It is meant
 //! to be used in development and testing.
 
-use std::{borrow::Cow, marker::PhantomData};
+use std::marker::PhantomData;
 
 use anyhow::anyhow;
 use async_trait::async_trait;
@@ -37,14 +37,14 @@ impl WikiFruit {
 }
 
 #[async_trait]
-impl<'a> SuggestionProvider<'a> for WikiFruit {
-    fn name(&self) -> Cow<'a, str> {
-        Cow::from("WikiFruit")
+impl SuggestionProvider for WikiFruit {
+    fn name(&self) -> String {
+        "WikiFruit".to_string()
     }
 
     async fn suggest(
         &self,
-        request: SuggestionRequest<'a>,
+        request: SuggestionRequest,
     ) -> Result<SuggestionResponse, SuggestError> {
         let suggestion = match request.query.as_ref() {
             "apple" => Some(Suggestion {

--- a/merino-web/Cargo.toml
+++ b/merino-web/Cargo.toml
@@ -8,6 +8,7 @@ actix-cors = "0.6.0-beta.1"
 actix-web = "=4.0.0-beta.8"
 actix-web-location = { version = "0.2", features = ["maxmind", "actix-web-v4", "cadence"] }
 anyhow = "1.0.40"
+async-recursion = "0.3"
 cadence = "0.26"
 futures-util = "0.3"
 lazy_static = "1.4.0"

--- a/merino-web/src/extractors.rs
+++ b/merino-web/src/extractors.rs
@@ -1,6 +1,5 @@
 //! Types to extract merino data from requests.
 
-use std::borrow::Cow;
 use std::str::FromStr;
 
 use crate::errors::HandlerError;
@@ -29,9 +28,9 @@ lazy_static! {
 }
 
 /// An extractor for a [`merino_suggest::SuggestionRequest`].
-pub struct SuggestionRequestWrapper<'a>(pub SuggestionRequest<'a>);
+pub struct SuggestionRequestWrapper(pub SuggestionRequest);
 
-impl<'a> FromRequest for SuggestionRequestWrapper<'a> {
+impl FromRequest for SuggestionRequestWrapper {
     type Config = ();
 
     type Error = ActixError;
@@ -62,12 +61,12 @@ impl<'a> FromRequest for SuggestionRequestWrapper<'a> {
             )?;
 
             Ok(Self(SuggestionRequest {
-                query: query.into(),
+                query,
                 accepts_english: supported_languages.includes("en", None),
-                country: location.country.map(Cow::from),
-                region: location.region.map(Cow::from),
+                country: location.country,
+                region: location.region,
                 dma: location.dma,
-                city: location.city.map(Cow::from),
+                city: location.city,
                 device_info,
             }))
         }

--- a/merino-web/src/lib.rs
+++ b/merino-web/src/lib.rs
@@ -96,8 +96,12 @@ pub fn run(
 
         if let Some(ref mmdb) = settings.location.maxmind_database {
             config = config.with_provider(
-                actix_web_location::providers::MaxMindProvider::from_path(mmdb)
-                    .context("Could not set maxmind location provider")?,
+                actix_web_location::providers::MaxMindProvider::from_path(mmdb).context(
+                    format!(
+                        "Could not set up maxmind location provider with database at {}",
+                        mmdb.to_string_lossy(),
+                    ),
+                )?,
             );
         }
 

--- a/merino-web/src/suggest.rs
+++ b/merino-web/src/suggest.rs
@@ -7,11 +7,14 @@ use actix_web::{
     HttpResponse,
 };
 use anyhow::Result;
+use async_recursion::async_recursion;
 use cadence::{Histogrammed, StatsdClient};
 use merino_adm::remote_settings::RemoteSettingsSuggester;
 use merino_cache::{MemoryCacheSuggester, RedisCacheSuggester};
-use merino_settings::{CacheType, Settings};
-use merino_suggest::{DebugProvider, Suggestion, SuggestionProvider, WikiFruit};
+use merino_settings::{providers::SuggestionProviderConfig, Settings};
+use merino_suggest::{
+    DebugProvider, Multi, NullProvider, Suggestion, SuggestionProvider, WikiFruit,
+};
 use serde::Serialize;
 use tokio::sync::OnceCell;
 use tracing_futures::Instrument;
@@ -91,44 +94,15 @@ impl SuggestionProviderRef {
         self.0
             .get_or_try_init(|| {
                 async {
-                    let settings = settings;
                     tracing::info!(
                         r#type = "web.configuring-suggesters",
                         "Setting up suggestion providers"
                     );
 
-                    /// The number of providers we expect to have, so we usually
-                    /// don't have to re-allocate the vec.
-                    const NUM_PROVIDERS: usize = 3;
                     let mut providers: Vec<Box<dyn SuggestionProvider>> =
-                        Vec::with_capacity(NUM_PROVIDERS);
-
-                    if settings.providers.wiki_fruit.enabled {
-                        let wikifruit = WikiFruit::new_boxed(settings)?;
-                        providers.push(match settings.providers.wiki_fruit.cache {
-                            CacheType::None => wikifruit,
-                            CacheType::Redis => {
-                                RedisCacheSuggester::new_boxed(settings, wikifruit).await?
-                            }
-                            CacheType::Memory => {
-                                MemoryCacheSuggester::new_boxed(settings, wikifruit)
-                            }
-                        });
-                    }
-
-                    if settings.providers.adm_rs.enabled {
-                        let adm_rs = RemoteSettingsSuggester::new_boxed(settings).await?;
-                        providers.push(match settings.providers.adm_rs.cache {
-                            CacheType::None => adm_rs,
-                            CacheType::Redis => {
-                                RedisCacheSuggester::new_boxed(settings, adm_rs).await?
-                            }
-                            CacheType::Memory => MemoryCacheSuggester::new_boxed(settings, adm_rs),
-                        });
-                    }
-
-                    if settings.providers.enable_debug_provider {
-                        providers.push(DebugProvider::new_boxed(settings)?);
+                        Vec::with_capacity(settings.suggestion_providers.len());
+                    for config in settings.suggestion_providers.values() {
+                        providers.push(make_provider_tree(settings, config).await?);
                     }
 
                     let multi = merino_suggest::Multi::new(providers);
@@ -138,6 +112,42 @@ impl SuggestionProviderRef {
             })
             .await
     }
+}
+
+/// Recursive helper to build a tree of providers.
+#[async_recursion]
+async fn make_provider_tree(
+    settings: &Settings,
+    config: &SuggestionProviderConfig,
+) -> Result<Box<dyn SuggestionProvider>> {
+    let provider: Box<dyn SuggestionProvider> = match config {
+        SuggestionProviderConfig::RemoteSettings(rs_config) => {
+            RemoteSettingsSuggester::new_boxed(settings, rs_config).await?
+        }
+
+        SuggestionProviderConfig::MemoryCache(memory_config) => {
+            let inner = make_provider_tree(settings, memory_config.inner.as_ref()).await?;
+            MemoryCacheSuggester::new_boxed(memory_config, inner)
+        }
+
+        SuggestionProviderConfig::RedisCache(redis_config) => {
+            let inner = make_provider_tree(settings, redis_config.inner.as_ref()).await?;
+            RedisCacheSuggester::new_boxed(settings, redis_config, inner).await?
+        }
+
+        SuggestionProviderConfig::Multiplexer(multi_config) => {
+            let mut providers = Vec::new();
+            for config in &multi_config.providers {
+                providers.push(make_provider_tree(settings, config).await?);
+            }
+            Multi::new_boxed(providers)
+        }
+
+        SuggestionProviderConfig::Debug => DebugProvider::new_boxed(settings)?,
+        SuggestionProviderConfig::WikiFruit => WikiFruit::new_boxed(settings)?,
+        SuggestionProviderConfig::Null => Box::new(NullProvider),
+    };
+    Ok(provider)
 }
 
 /// A mapper from the internal schema used by merino-suggest to the expected API.
@@ -178,5 +188,53 @@ impl<'a> Serialize for SuggestionWrapper<'a> {
         };
 
         generated.serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::make_provider_tree;
+    use anyhow::Result;
+    use merino_settings::{
+        providers::{
+            MemoryCacheConfig, MultiplexerConfig, RedisCacheConfig, SuggestionProviderConfig,
+        },
+        Settings,
+    };
+
+    #[tokio::test]
+    async fn test_providers_single() -> Result<()> {
+        let settings = Settings::load_for_tests();
+        let config = SuggestionProviderConfig::Null;
+        let provider_tree = make_provider_tree(&settings, &config).await?;
+        assert_eq!(provider_tree.name(), "NullProvider");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_providers_complex() -> Result<()> {
+        let mut settings = Settings::load_for_tests();
+        settings.debug = true;
+
+        let config = SuggestionProviderConfig::Multiplexer(MultiplexerConfig {
+            providers: vec![
+                SuggestionProviderConfig::Null,
+                SuggestionProviderConfig::RedisCache(RedisCacheConfig {
+                    inner: Box::new(SuggestionProviderConfig::MemoryCache(MemoryCacheConfig {
+                        inner: Box::new(SuggestionProviderConfig::WikiFruit),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                }),
+                SuggestionProviderConfig::Null,
+            ],
+        });
+
+        let provider_tree = make_provider_tree(&settings, &config).await?;
+        assert_eq!(
+            provider_tree.name(),
+            "Multi(NullProvider, RedisCache(MemoryCache(WikiFruit)), NullProvider)"
+        );
+        Ok(())
     }
 }

--- a/merino/src/docs/testing.rs
+++ b/merino/src/docs/testing.rs
@@ -1,7 +1,9 @@
 //! # Testing strategies
 //!
-//! There are two major testing strategies used in this repository: unit tests,
-//! and integration tests.
+//! There are three major testing strategies used in this repository: unit tests,
+//! Rust integration tests, and Python system tests.
+//!
+//! ## Unit Tests
 //!
 //! Unit tests should appear close to the code they are testing, using standard
 //! Rust unit tests. This is suitable for testing complex behavior at a small
@@ -21,9 +23,11 @@
 //! }
 //! ```
 //!
-//! However, many behaviors are difficult to test as unit tests, especially
-//! details like the URLs we expose via the web service. To test these parts of
-//! Merino, we have [`merino-integration-tests`][test-crate], which starts an
+//! ## Integration tests
+//!
+//! Many behaviors are difficult to test as unit tests, especially details like
+//! the URLs we expose via the web service. To test these parts of Merino, we
+//! have [`merino-integration-tests`][test-crate], which starts a configurable
 //! instance of Merino with mock data sources. HTTP requests can then be made to
 //! that server in order to test its behavior.
 //!
@@ -51,3 +55,11 @@
 //!
 //! For more details, see the documentation of the `merino-integration-tests`
 //! crate.
+//!
+//! ## System tests
+//!
+//! The tests in the `test-engineering` directory are system tests that consume
+//! Merino's APIs using more opaque techniques. They cannot configure the server
+//! per test, and are more concerned with external contracts and behavior.
+//!
+//! For more details see the README.md file in the `test-engineering` directory.

--- a/test-engineering/README.md
+++ b/test-engineering/README.md
@@ -1,13 +1,13 @@
 # test-engineering
 
-This directory contains source code for automated integration tests for Merino.
+This directory contains source code for automated system tests for Merino.
 
 **Please note that this is work in progress.** 🚧
 
 ## Run tests locally
 
-You can run the integration tests locally from the repository root directory using:
+You can run the system tests locally from the repository root directory using:
 
 ```text
-docker compose -f test-engineering/docker-compose.yml up --abort-on-container-exit --build
+docker-compose -f test-engineering/docker-compose.yml up --abort-on-container-exit --build
 ```

--- a/test-engineering/client/Dockerfile
+++ b/test-engineering/client/Dockerfile
@@ -13,4 +13,4 @@ RUN python -m pip install -r /tmp/requirements.txt
 COPY . /usr/src/client
 WORKDIR /usr/src/client
 
-ENTRYPOINT [ "pytest" ]
+CMD [ "pytest" ]

--- a/test-engineering/docker-compose.yml
+++ b/test-engineering/docker-compose.yml
@@ -3,26 +3,11 @@ services:
   merino:
     # See `docker-image-build` job in `.circleci/config.yml`
     image: app:build
+    build: ..
     container_name: merino
     environment:
-      # Enable additional features to debug the application
-      MERINO_DEBUG: "true"
-      # The environment Merino is running in
-      MERINO_ENV: "development"
-      # The host and port Merino listens on
-      MERINO_HTTP__LISTEN: "0.0.0.0:8000"
-      # The location of the maxmind database to use to determine IP location
-      MERINO_LOCATION__MAXMIND_DATABASE: "/tmp/dev/GeoLite2-City-Test.mmdb"
-      # The minimum level that logs should be reported at
-      MERINO_LOGGING__LEVELS: "DEBUG"
-      # Whether the adM Remote Settings-based provider should be active
-      MERINO_PROVIDERS__ADM_RS__ENABLED: "false"
-      # Remote Settings-based provider
-      MERINO_PROVIDERS__ENABLE_DEBUG_PROVIDER: "false"
-      # Whether the WikiFruit development provider should be active
-      MERINO_PROVIDERS__WIKI_FRUIT__ENABLED: "true"
-      # Mode of the Sentry error and event reporting system
-      MERINO_SENTRY__MODE: "disabled"
+      # The configuration preset to use
+      MERINO_ENV: "ci"
     volumes:
       - ../dev:/tmp/dev
 
@@ -34,8 +19,9 @@ services:
       - merino
     volumes:
       - ./volumes/client:/tmp/client
+      - ../dev/wait-for-it.sh:/wait-for-it.sh
     environment:
       MERINO_URL: http://merino:8000
       SCENARIOS_FILE: /tmp/client/scenarios.yml
     command: >
-      "-vv"
+      /wait-for-it.sh merino:8000 -- pytest -vv

--- a/test-engineering/docker-compose.yml
+++ b/test-engineering/docker-compose.yml
@@ -24,4 +24,4 @@ services:
       MERINO_URL: http://merino:8000
       SCENARIOS_FILE: /tmp/client/scenarios.yml
     command: >
-      /wait-for-it.sh merino:8000 -- pytest -vv
+      /wait-for-it.sh merino:8000 --strict -- pytest -vv


### PR DESCRIPTION
- Remove Cows and lifetimes from providers and box all of them
- feat(settings): Make suggestion providers much more configurable at runtime

fixes #120 

BREAKING CHANGE: The configuration of providers is more free-form now, and the old settings will need updated.