### PR TITLE
refactor(adm): Remove usage of remote-settings-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,19 +978,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "canonical_json"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f464b27d56e99fb36031754bb17fe97f1a69f66621628f002664cee6a4bcbf"
-dependencies = [
- "hex",
- "regex",
- "serde 1.0.126",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,16 +1209,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
-dependencies = [
- "darling_core 0.12.4",
- "darling_macro 0.12.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "757c0ded2af11d8e739c4daea1ac623dd1624b06c844cf3f5a39f1bdbd99bb12"
@@ -1256,20 +1233,6 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn",
-]
-
-[[package]]
-name = "darling_core"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c34d8efb62d0c2d7f60ece80f75e5c63c1588ba68032740494b0b9a996466e3"
@@ -1289,17 +1252,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core 0.10.2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
-dependencies = [
- "darling_core 0.12.4",
  "quote",
  "syn",
 ]
@@ -1346,37 +1298,6 @@ checksum = "f91cf5a8c2f2097e2a32627123508635d47ce10563d999ec1a95addf08b502ba"
 dependencies = [
  "serde 1.0.126",
  "uuid",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d13202debe11181040ae9063d739fa32cfcaaebe2275fe387703460ae2365b30"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66e616858f6187ed828df7c64a6d71720d83767a7f19740b2d1b6fe6327b36e5"
-dependencies = [
- "darling 0.12.4",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58a94ace95092c5acb1e97a7e846b310cfbd499652f72297da7493f618a98d73"
-dependencies = [
- "derive_builder_core",
- "syn",
 ]
 
 [[package]]
@@ -1544,16 +1465,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77b705829d1e87f762c2df6da140b26af5839e1033aa84aa5f56bb688e4e1bdb"
 dependencies = [
  "instant",
-]
-
-[[package]]
-name = "ffi-support"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f476e3c4fa6d9a3e0eeabd4f7555a382025ec05194675d72fa1db347e53ae6c"
-dependencies = [
- "lazy_static",
- "log",
 ]
 
 [[package]]
@@ -1884,12 +1795,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
 name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2156,15 +2061,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
@@ -2226,7 +2122,7 @@ dependencies = [
  "bit-set",
  "diff",
  "ena",
- "itertools 0.10.1",
+ "itertools",
  "lalrpop-util",
  "petgraph",
  "pico-args",
@@ -2422,8 +2318,6 @@ dependencies = [
  "tracing-actix-web-mozlog",
  "tracing-log",
  "tracing-subscriber",
- "viaduct",
- "viaduct-reqwest",
 ]
 
 [[package]]
@@ -2436,12 +2330,12 @@ dependencies = [
  "fake",
  "futures",
  "http",
+ "httpmock",
  "lazy_static",
  "merino-settings",
  "merino-suggest",
  "pretty_assertions",
  "radix_trie",
- "remote-settings-client",
  "reqwest 0.11.4",
  "serde 1.0.126",
  "serde_derive",
@@ -2451,7 +2345,6 @@ dependencies = [
  "thiserror",
  "tokio 1.9.0",
  "tracing",
- "viaduct",
 ]
 
 [[package]]
@@ -2506,8 +2399,6 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
- "viaduct",
- "viaduct-reqwest",
 ]
 
 [[package]]
@@ -2821,15 +2712,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
-name = "openssl-src"
-version = "111.16.0+1.1.1l"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab2173f69416cf3ec12debb5823d244127d23a9b127d5a5189aa97c5fa2859f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2838,7 +2720,6 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -3093,29 +2974,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
-dependencies = [
- "bytes 0.5.6",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
-dependencies = [
- "anyhow",
- "itertools 0.8.2",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "qstring"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3320,22 +3178,6 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
-
-[[package]]
-name = "remote-settings-client"
-version = "0.1.0"
-source = "git+https://github.com/mozilla-services/remote-settings-client?rev=06fbe92e3e45c42ff1bdd9b71ceda6e9e908a656#06fbe92e3e45c42ff1bdd9b71ceda6e9e908a656"
-dependencies = [
- "base64",
- "canonical_json",
- "derive_builder",
- "log",
- "serde 1.0.126",
- "serde_json",
- "thiserror",
- "url",
- "viaduct",
-]
 
 [[package]]
 name = "remove_dir_all"
@@ -4552,34 +4394,6 @@ name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
-
-[[package]]
-name = "viaduct"
-version = "0.1.0"
-source = "git+https://github.com/mozilla/application-services?rev=v75.0.0#4ea7d677f1c62bb175226e2a6d2ccd79cf4bff4d"
-dependencies = [
- "ffi-support",
- "log",
- "once_cell",
- "prost",
- "prost-derive",
- "serde 1.0.126",
- "serde_json",
- "thiserror",
- "url",
-]
-
-[[package]]
-name = "viaduct-reqwest"
-version = "0.1.0"
-source = "git+https://github.com/mozilla/application-services?rev=v75.0.0#4ea7d677f1c62bb175226e2a6d2ccd79cf4bff4d"
-dependencies = [
- "ffi-support",
- "lazy_static",
- "log",
- "reqwest 0.10.10",
- "viaduct",
-]
 
 [[package]]
 name = "wait-timeout"

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -10,7 +10,7 @@ redis:
   url: redis://127.0.0.1:6379
 
 remote_settings:
-  storage_path: "./rs-cache"
+  server: "https://firefox.settings.services.mozilla.com"
 
 logging:
   levels: [INFO]

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -122,9 +122,6 @@ Connection to Redis. This is used by the Redis provider cache below.
 Connection to Remote Settings. This is used by the Remote Settings suggestion
 provider below.
 
-- `remote_settings.storage_path` (`MERINO_REMOTE_SETTINGS__STORAGE_PATH`) - The
-  local disk path where the Remote Settings client can store synchronized data
-  to save on future bandwidth.
 - `remote_settings.server` (`MERINO_REMOTE_SETTINGS__SERVER`) - The server to
   sync from. Example: `https://firefox.settings.services.mozilla.com`.
 

--- a/merino-adm/Cargo.toml
+++ b/merino-adm/Cargo.toml
@@ -12,7 +12,6 @@ lazy_static = "1.4.0"
 merino-settings = { path = "../merino-settings" }
 merino-suggest = { path = "../merino-suggest" }
 radix_trie = "0.2.1"
-remote-settings-client = { git = "https://github.com/mozilla-services/remote-settings-client", rev = "06fbe92e3e45c42ff1bdd9b71ceda6e9e908a656" }
 reqwest = { version = "0.11.3", features = ["json"] }
 serde = "1.0.125"
 serde_derive = "1.0.125"
@@ -22,9 +21,9 @@ serde_with = "1.9"
 thiserror = "1.0"
 tokio = { version = "1.8.2", features = ["rt", "macros", "rt-multi-thread"] }
 tracing = "0.1.26"
-viaduct = { git = "https://github.com/mozilla/application-services", rev = "v75.0.0" }
 
 [dev-dependencies]
 actix-rt = "2.2"
-pretty_assertions = "0.7.1"
 fake = "2"
+httpmock = "0.5.8"
+pretty_assertions = "0.7.1"

--- a/merino-integration-tests/Cargo.toml
+++ b/merino-integration-tests/Cargo.toml
@@ -27,5 +27,3 @@ tokio-test = "0.4.1"
 tracing = "0.1.26"
 tracing-futures = "0.2"
 tracing-subscriber = "0.2.18"
-viaduct = { git = "https://github.com/mozilla/application-services", rev = "v75.0.0" }
-viaduct-reqwest = { git = "https://github.com/mozilla/application-services", rev = "v75.0.0" }

--- a/merino-integration-tests/src/suggest.rs
+++ b/merino-integration-tests/src/suggest.rs
@@ -135,27 +135,9 @@ async fn suggest_adm_rs_works(
 fn setup_empty_remote_settings_collection(server: MockServer) {
     server.mock(|when, then| {
         when.method(GET)
-            .path("/buckets/monitor/collections/changes/changeset");
+            .path("/v1/buckets/main/collections/quicksuggest/records");
         then.status(200).json_body(json!({
-            "metadata": {},
-            "changes": [{
-                "bucket": "main",
-                "collection": "quicksuggest",
-                "last_modified": 0,
-            }],
-            "timestamp": 0,
-            "backoff": null,
-        }));
-    });
-
-    server.mock(|when, then| {
-        when.method(GET)
-            .path("/buckets/main/collections/quicksuggest/changeset");
-        then.status(200).json_body(json!({
-            "metadata": {},
-            "changes": [],
-            "timestamp": 0,
-            "backoff": null,
+            "data": [],
         }));
     });
 }

--- a/merino-settings/src/lib.rs
+++ b/merino-settings/src/lib.rs
@@ -144,12 +144,12 @@ pub struct RedisSettings {
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RemoteSettingsGlobalSettings {
-    /// The path, relative or absolute, to where to store Remote Settings data.
-    pub storage_path: PathBuf,
-
-    /// The server to sync from. If no value is provided, a default is provided
-    /// by the remote settings client.
-    pub server: Option<String>,
+    /// The server to sync from, including the protocol and port, but not including a trailing slash.
+    ///
+    /// ## Examples
+    /// - `http://127.0.0.1`
+    /// - `https://firefox.settings.services.mozilla.com`
+    pub server: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/merino-settings/src/providers.rs
+++ b/merino-settings/src/providers.rs
@@ -119,6 +119,9 @@ impl Default for MemoryCacheConfig {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct RemoteSettingsConfig {
+    /// The Remote Settings bucket to read from
+    pub bucket: String,
+
     /// The collection to sync form.
     pub collection: String,
 }
@@ -126,6 +129,7 @@ pub struct RemoteSettingsConfig {
 impl Default for RemoteSettingsConfig {
     fn default() -> Self {
         Self {
+            bucket: "main".to_string(),
             collection: "quicksuggest".to_string(),
         }
     }

--- a/merino-web/src/suggest.rs
+++ b/merino-web/src/suggest.rs
@@ -43,7 +43,7 @@ struct SuggestResponse<'a> {
 struct SuggestQueryParameters {
     #[serde_as(as = "StringWithSeparator::<CommaSeparator, String>")]
     #[serde(default)]
-    /// Query Paramater for client_variants
+    /// Query Parameter for client_variants
     client_variants: Vec<String>,
 }
 /// Customizes the output format of [`Suggestion`].
@@ -52,7 +52,7 @@ struct SuggestionWrapper<'a>(&'a Suggestion);
 
 /// Suggest content in response to the queried text.
 #[get("")]
-#[tracing::instrument(skip(suggestion_request, provider, settings))]
+#[tracing::instrument(skip(suggestion_request, provider, metrics_client, settings))]
 async fn suggest(
     SuggestionRequestWrapper(suggestion_request): SuggestionRequestWrapper,
     provider: Data<SuggestionProviderRef>,

--- a/merino/Cargo.toml
+++ b/merino/Cargo.toml
@@ -15,8 +15,6 @@ tracing = "0.1.26"
 tracing-actix-web-mozlog = "0.3"
 tracing-log = "0.1.2"
 tracing-subscriber = { version = "0.2.18", features = ["registry", "env-filter"] }
-viaduct = { git = "https://github.com/mozilla/application-services", rev = "v75.0.0" }
-viaduct-reqwest = { git = "https://github.com/mozilla/application-services", rev = "v75.0.0" }
 
 [dependencies.sentry]
 # Pin Sentry to 0.19 until our on premise Sentry server upgrades to at least 20.6

--- a/merino/src/main.rs
+++ b/merino/src/main.rs
@@ -12,7 +12,6 @@ use tracing::Level;
 use tracing_actix_web_mozlog::{JsonStorageLayer, MozLogFormatLayer};
 use tracing_log::LogTracer;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter};
-use viaduct_reqwest::ReqwestBackend;
 
 /// Primary entry point
 #[actix_rt::main]
@@ -21,8 +20,6 @@ async fn main() -> Result<()> {
     let _sentry_guard = crate::sentry::init_sentry(&settings).context("initializing sentry")?;
     init_logging(&settings).context("initializing logging")?;
     let metrics_client = init_metrics(&settings).context("initializing metrics")?;
-
-    viaduct::set_backend(&ReqwestBackend).context("setting viaduct backend")?;
 
     let listener = TcpListener::bind(settings.http.listen).context("Binding port")?;
     merino_web::run(listener, metrics_client, settings)


### PR DESCRIPTION
Notably, there is no longer any attempt at all to cache data from Remote
Settings, and signatures are not verified.

Fixes #131
