### PR TITLE
feat: Report stacktraces for errors to Sentry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2457,6 +2457,7 @@ dependencies = [
  "actix-web-location",
  "anyhow",
  "async-recursion",
+ "backtrace",
  "cadence",
  "futures-util",
  "lazy_static",

--- a/merino-web/Cargo.toml
+++ b/merino-web/Cargo.toml
@@ -9,6 +9,7 @@ actix-web = "=4.0.0-beta.8"
 actix-web-location = { version = "0.2", features = ["maxmind", "actix-web-v4", "cadence"] }
 anyhow = "1.0.40"
 async-recursion = "0.3"
+backtrace = "0.3"
 cadence = "0.26"
 futures-util = "0.3"
 lazy_static = "1.4.0"

--- a/merino-web/src/endpoints/dockerflow.rs
+++ b/merino-web/src/endpoints/dockerflow.rs
@@ -149,7 +149,7 @@ async fn test_error(
                 r#type = "dockerflow.error_endpoint",
                 "The __error__ endpoint was called"
             );
-            Err(HandlerError::Internal)
+            Err(HandlerError::internal())
         }
     }
 }

--- a/merino-web/src/endpoints/providers.rs
+++ b/merino-web/src/endpoints/providers.rs
@@ -32,7 +32,7 @@ async fn list_providers(
                 r#type = "web.suggest.setup-error",
                 "suggester error"
             );
-            HandlerError::Internal
+            HandlerError::internal()
         })?;
 
     let providers = provider

--- a/merino-web/src/endpoints/suggest.rs
+++ b/merino-web/src/endpoints/suggest.rs
@@ -41,7 +41,7 @@ async fn suggest(
                 r#type = "web.suggest.setup-error",
                 "suggester error"
             );
-            HandlerError::Internal
+            HandlerError::internal()
         })?;
 
     let response = match &query_parameters.providers {
@@ -54,7 +54,7 @@ async fn suggest(
     }
     .map_err(|error| {
         tracing::error!(%error, r#type="web.suggest.error", "Error providing suggestions");
-        HandlerError::Internal
+        HandlerError::internal()
     })?;
 
     tracing::debug!(

--- a/merino-web/src/errors.rs
+++ b/merino-web/src/errors.rs
@@ -1,4 +1,14 @@
 //! Any errors that merino-web might generate, and supporting implementations.
+//!
+//! This module implements the supporting functionalities to manipulate
+//! [crate::error::HandlerError] to make it esier to send them to Sentry.
+//! The [crate::error::HandlerError] wraps the internal error [crate::error::HandlerErrorKind]
+//! and the related backtrace. Such backtrace is captured when converting from
+//! [crate::error::HandlerErrorKind] to [crate::error::HandlerError] using `into()`.
+//! Developers are expected to use [crate::error::HandlerError] as the error type of
+//! their functions and to set the appropriate error by e.g. `Err(HandlerErrorKind::Internal.into())`.
+//!
+//! New errors can be added by extending [crate::error::HandlerErrorKind].
 
 use std::collections::HashMap;
 use std::error::Error;
@@ -11,6 +21,9 @@ use thiserror::Error;
 
 /// The Standard Error for most of Merino
 pub struct HandlerError {
+    // Important: please make sure to update the implementation of
+    // std::fmt::Debug for this struct if new fields are added here.
+
     /// The wrapped error value.
     kind: HandlerErrorKind,
     /// The backtrace related to the wrapped error.
@@ -60,6 +73,9 @@ impl HandlerError {
     }
 
     /// Get an `HandlerError` representing an `Internal` error.
+    ///
+    /// This is a convenience function: the same result can be
+    /// achieved by directly using `HandlerErrorKind::Internal.into()`.
     pub fn internal() -> Self {
         HandlerErrorKind::Internal.into()
     }

--- a/merino-web/src/errors.rs
+++ b/merino-web/src/errors.rs
@@ -10,7 +10,6 @@ use serde_json::Value;
 use thiserror::Error;
 
 /// The Standard Error for most of Merino
-#[derive(Debug)]
 pub struct HandlerError {
     /// The wrapped error value.
     kind: HandlerErrorKind,
@@ -87,6 +86,20 @@ where
 impl fmt::Display for HandlerError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.kind.fmt(f)
+    }
+}
+
+impl std::fmt::Debug for HandlerError {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        // Sentry will scan the printed debug information for `HandlerError`
+        // to determine the "event type" to display and to group events by:
+        // to make sure different errors don't get grouped together, we format
+        // the name of this debug struct as `HandlerError/<error name>`.
+        // See `sentry::parse_type_from_debug` used by middleware/sentry.rs
+        fmt.debug_struct(&format!("HandlerError/{:?}", &self.kind))
+            .field("kind", &self.kind)
+            .field("backtrace", &self.backtrace)
+            .finish()
     }
 }
 

--- a/merino-web/src/errors.rs
+++ b/merino-web/src/errors.rs
@@ -12,7 +12,9 @@ use thiserror::Error;
 /// The Standard Error for most of Merino
 #[derive(Debug)]
 pub struct HandlerError {
+    /// The wrapped error value.
     kind: HandlerErrorKind,
+    /// The backtrace related to the wrapped error.
     pub(crate) backtrace: Backtrace,
 }
 
@@ -29,6 +31,7 @@ pub enum HandlerErrorKind {
 }
 
 impl HandlerErrorKind {
+    /// Convert the error to an HTTP status code.
     pub fn status_code(&self) -> StatusCode {
         match self {
             Self::Internal => StatusCode::INTERNAL_SERVER_ERROR,
@@ -36,6 +39,7 @@ impl HandlerErrorKind {
         }
     }
 
+    /// Build an HTTP response reporting the error.
     pub fn error_response(&self) -> HttpResponse {
         let mut response = HashMap::new();
         response.insert("error".to_owned(), Value::String(format!("{}", self)));
@@ -51,10 +55,12 @@ impl From<HandlerErrorKind> for actix_web::Error {
 }
 
 impl HandlerError {
+    /// Access the wrapped error.
     pub fn kind(&self) -> &HandlerErrorKind {
         &self.kind
     }
 
+    /// Get an `HandlerError` representing an `Internal` error.
     pub fn internal() -> Self {
         HandlerErrorKind::Internal.into()
     }

--- a/merino-web/src/errors.rs
+++ b/merino-web/src/errors.rs
@@ -3,10 +3,14 @@
 //! This module implements the supporting functionalities to manipulate
 //! [crate::error::HandlerError] to make it esier to send them to Sentry.
 //! The [crate::error::HandlerError] wraps the internal error [crate::error::HandlerErrorKind]
-//! and the related backtrace. Such backtrace is captured when converting from
-//! [crate::error::HandlerErrorKind] to [crate::error::HandlerError] using `into()`.
+//! and a related backtrace.
+//! The corresponding backtrace is captured when the error is created.
+//! This happens automatically when a [crate::error::HandlerErrorKind] is converted into a [crate::error::HandlerError].
+//!
 //! Developers are expected to use [crate::error::HandlerError] as the error type of
-//! their functions and to set the appropriate error by e.g. `Err(HandlerErrorKind::Internal.into())`.
+//! their functions and to set the appropriate error by
+//! * explicitly converting it using `into()`, e.g. `Err(HandlerErrorKind::Internal.into())`,
+//! * implicitly converting it using the question mark operator, e.g. `Err(HandleErrorKind::Interal)?`.
 //!
 //! New errors can be added by extending [crate::error::HandlerErrorKind].
 

--- a/merino-web/src/errors.rs
+++ b/merino-web/src/errors.rs
@@ -1,14 +1,24 @@
 //! Any errors that merino-web might generate, and supporting implementations.
 
 use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
 
 use actix_web::{http::StatusCode, HttpResponse, ResponseError};
+use backtrace::Backtrace;
 use serde_json::Value;
 use thiserror::Error;
 
+/// The Standard Error for most of Merino
+#[derive(Debug)]
+pub struct HandlerError {
+    kind: HandlerErrorKind,
+    pub(crate) backtrace: Backtrace,
+}
+
 /// An error that happened in a web handler.
 #[derive(Error, Debug)]
-pub enum HandlerError {
+pub enum HandlerErrorKind {
     /// A generic error, when there is nothing more specific to say.
     #[error("Internal error")]
     Internal,
@@ -18,17 +28,73 @@ pub enum HandlerError {
     MalformedHeader(&'static str),
 }
 
-impl ResponseError for HandlerError {
-    fn status_code(&self) -> StatusCode {
+impl HandlerErrorKind {
+    pub fn status_code(&self) -> StatusCode {
         match self {
             Self::Internal => StatusCode::INTERNAL_SERVER_ERROR,
             Self::MalformedHeader(_) => StatusCode::BAD_REQUEST,
         }
     }
 
-    fn error_response(&self) -> HttpResponse {
+    pub fn error_response(&self) -> HttpResponse {
         let mut response = HashMap::new();
         response.insert("error".to_owned(), Value::String(format!("{}", self)));
+        HttpResponse::InternalServerError().json(response)
+    }
+}
+
+impl From<HandlerErrorKind> for actix_web::Error {
+    fn from(kind: HandlerErrorKind) -> Self {
+        let error: HandlerError = kind.into();
+        error.into()
+    }
+}
+
+impl HandlerError {
+    pub fn kind(&self) -> &HandlerErrorKind {
+        &self.kind
+    }
+
+    pub fn internal() -> Self {
+        HandlerErrorKind::Internal.into()
+    }
+}
+
+impl Error for HandlerError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.kind.source()
+    }
+}
+
+impl<T> From<T> for HandlerError
+where
+    HandlerErrorKind: From<T>,
+{
+    fn from(item: T) -> Self {
+        HandlerError {
+            kind: HandlerErrorKind::from(item),
+            backtrace: Backtrace::new(),
+        }
+    }
+}
+
+impl fmt::Display for HandlerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.kind.fmt(f)
+    }
+}
+
+impl ResponseError for HandlerError {
+    fn status_code(&self) -> StatusCode {
+        self.kind().status_code()
+    }
+
+    fn error_response(&self) -> HttpResponse {
+        let mut response = HashMap::new();
+        response.insert(
+            "error".to_owned(),
+            Value::String(format!("{}", self.kind())),
+        );
         HttpResponse::InternalServerError().json(response)
     }
 }

--- a/merino-web/src/errors.rs
+++ b/merino-web/src/errors.rs
@@ -23,7 +23,6 @@ use thiserror::Error;
 pub struct HandlerError {
     // Important: please make sure to update the implementation of
     // std::fmt::Debug for this struct if new fields are added here.
-
     /// The wrapped error value.
     kind: HandlerErrorKind,
     /// The backtrace related to the wrapped error.

--- a/merino-web/src/extractors.rs
+++ b/merino-web/src/extractors.rs
@@ -2,7 +2,7 @@
 
 use std::str::FromStr;
 
-use crate::errors::HandlerError;
+use crate::errors::{HandlerError, HandlerErrorKind};
 use actix_web::{
     dev::Payload,
     http::{header, HeaderValue},
@@ -95,16 +95,16 @@ impl FromRequest for SupportedLanguagesWrapper {
         fn parse_quality_value(quality_value: &str) -> Result<f64, HandlerError> {
             let (_, weight_as_string) = quality_value
                 .split_once('=')
-                .ok_or(HandlerError::MalformedHeader("Accept-Language"))?;
+                .ok_or(HandlerErrorKind::MalformedHeader("Accept-Language"))?;
 
             let weight = weight_as_string
                 .parse::<f64>()
-                .map_err(|_| HandlerError::MalformedHeader("Accept-Language"))?;
+                .map_err(|_| HandlerErrorKind::MalformedHeader("Accept-Language"))?;
 
             if (0.0..=1.0).contains(&weight) {
                 Ok(weight)
             } else {
-                Err(HandlerError::MalformedHeader("Accept-Language"))
+                Err(HandlerErrorKind::MalformedHeader("Accept-Language").into())
             }
         }
 
@@ -150,7 +150,7 @@ impl FromRequest for SupportedLanguagesWrapper {
         let parse_header = || {
             let header = match req.headers().get(header::ACCEPT_LANGUAGE) {
                 Some(header) => header.to_str().map_err::<Self::Error, _>(|_| {
-                    HandlerError::MalformedHeader("Accept-Language").into()
+                    HandlerErrorKind::MalformedHeader("Accept-Language").into()
                 }),
                 None => return Ok(Self(SupportedLanguages::wildcard())),
             }?;

--- a/merino-web/src/middleware/metrics.rs
+++ b/merino-web/src/middleware/metrics.rs
@@ -60,7 +60,7 @@ where
     fn poll_ready(&self, ctx: &mut Context<'_>) -> std::task::Poll<Result<(), Self::Error>> {
         self.service.poll_ready(ctx).map_err(|error| {
             tracing::error!(?error, "Error polling service from metrics middleware");
-            HandlerError::Internal.into()
+            HandlerError::internal().into()
         })
     }
 
@@ -71,7 +71,7 @@ where
         let fut = self.service.call(req);
 
         Box::pin(async move {
-            let response = fut.await.map_err(|_err| HandlerError::Internal)?;
+            let response = fut.await.map_err(|_err| HandlerError::internal())?;
             if let Some(metrics_client) = metrics_client {
                 let lapsed = Instant::now().duration_since(start);
                 metrics_client

--- a/merino-web/src/suggest.rs
+++ b/merino-web/src/suggest.rs
@@ -69,7 +69,7 @@ async fn suggest(
                 r#type = "web.suggest.setup-error",
                 "suggester error"
             );
-            HandlerError::Internal
+            HandlerError::internal()
         })?;
 
     let response = provider
@@ -77,7 +77,7 @@ async fn suggest(
         .await
         .map_err(|error| {
             tracing::error!(%error, r#type="web.suggest.error", "Error providing suggestions");
-            HandlerError::Internal
+            HandlerError::internal()
         })?;
 
     tracing::debug!(


### PR DESCRIPTION
Since the `err.backtrace()` is still unstable in Rust, this uses the same approach as [Contile via the Backtrace crate](https://github.com/mozilla-services/contile/issues/158).

Fixes #139 

Here's a [submitted sample error](https://sentry.prod.mozaws.net/operations/merino-local/issues/13572769/?query=is%3Aunresolved).