### PR TITLE
ops: Include target URL when failing to connect to Redis

### DIFF
--- a/merino-cache/src/redis/mod.rs
+++ b/merino-cache/src/redis/mod.rs
@@ -190,7 +190,10 @@ impl Suggester {
 
         let redis_connection = redis::aio::ConnectionManager::new(client)
             .await
-            .context("Connecting to Redis")
+            .context(format!(
+                "Connecting to Redis at {}",
+                settings.redis.redacted_url(),
+            ))
             .map_err(SetupError::Network)?;
 
         Ok(Box::new(Suggester {

--- a/merino-settings/src/lib.rs
+++ b/merino-settings/src/lib.rs
@@ -141,6 +141,27 @@ pub struct RedisSettings {
     pub url: ::redis::ConnectionInfo,
 }
 
+impl RedisSettings {
+    #[must_use]
+    pub fn redacted_url(&self) -> String {
+        match (&self.url.username, &self.url.passwd) {
+            (Some(username), Some(_)) => {
+                format!(
+                    "redis://{}:<PASSWORD>@{}/{}",
+                    username, self.url.addr, self.url.db
+                )
+            }
+            (Some(username), None) => {
+                format!("redis://{}@{}/{}", username, self.url.addr, self.url.db)
+            }
+            (None, Some(_password)) => {
+                format!("redis://:<PASSWORD>@{}/{}", self.url.addr, self.url.db)
+            }
+            (None, None) => format!("redis://{}/{}", self.url.addr, self.url.db),
+        }
+    }
+}
+
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RemoteSettingsGlobalSettings {


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/305049/136256518-7b75ed68-1443-4eff-b56e-9211be038af8.png)

After:

![image](https://user-images.githubusercontent.com/305049/136256480-760008a3-461c-487b-9584-a43f88d7b3c9.png)
