### PR TITLE
Add an exception for RUSTSEC-2020-0071

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -5,6 +5,10 @@ ignore = [
     "RUSTSEC-2020-0048", # False positive on actix-http. Affected versions are <2.0.0-alpha.1, we have 3.0.0-beta.5.
     "RUSTSEC-2020-0049", # False positive on actix-codec. Affected versions are <0.3.0-beta.1, we have 0.4.0-beta.1.
 
+    # Both Sentry and actix pull in a specific version of the time crate. Unfortunately
+    # these packages can't be updated as we are restricted by the server version.
+    "RUSTSEC-2020-0071", # Time 0.143 - Potential segfault in time crate.
+
     # Hyper is only used for Remote Settings syncing currently, which only
     # works with trusted servers. These two problems are acceptable for now,
     # but we should try to update this soon.


### PR DESCRIPTION
We'll be able to remove this exception once the sentry and actix packages will be updated.