### PR TITLE
devel: add a rustsec exception for chrono to unblock CI

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -19,4 +19,8 @@ ignore = [
     # update the Sentry libraries to get out of this, until our server has
     # upgraded. I've reviewed the CVE, and don't believe it affects im's usage.
     "RUSTSEC-2020-0041",
+
+    # While this is not a false positive, there is no recommended fix right
+    # now for the chrono problem, hence the exception.
+    "RUSTSEC-2020-0159", # Chrono 0.4.19 - Potential segfault in `localtime_r` invokations.
 ]


### PR DESCRIPTION
This is a follow-up that should make CI work again. Given that the advisory does not recommend any particular strategy, I propose to suppress this exception and create an issue to update chrono once it becomes available.