### PR TITLE
feat: add SuggestionRequest to tracing logs

### DIFF
--- a/config/base.yaml
+++ b/config/base.yaml
@@ -1,4 +1,5 @@
 debug: false
+log_full_request: false
 
 http:
   listen: "127.0.0.1:8080"

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -41,6 +41,8 @@ The names given below are of the form "`yaml.path` (`ENVIRONMENT_VAR`)"
   root of the server, they will be redirected to this URL. Preferable a public
   wiki page that explains what the server is and does.
 
+- `log_full_request` (`MERINO_LOG_FULL_REQUEST`) - Boolean that enables logging the entire suggestion request object as a part of the tracing log, including the search query. When the setting is false (default), the suggest request object should be logged, but the search query should be blank. Note that access to the collected query logs is restricted.
+
 ### HTTP
 
 Settings for the HTTP server.

--- a/merino-settings/src/lib.rs
+++ b/merino-settings/src/lib.rs
@@ -84,6 +84,12 @@ pub struct Settings {
 
     /// Settings to use when determining the location associated with requests.
     pub location: LocationSettings,
+
+    /// If on, log the entire suggestion request object as a part of the
+    /// tracing log, including the search query. When the setting is
+    /// off, the suggest request object should be logged, but the
+    /// search query should be blank.
+    pub log_full_request: bool,
 }
 
 /// Settings for the HTTP server.

--- a/merino-suggest/src/lib.rs
+++ b/merino-suggest/src/lib.rs
@@ -6,7 +6,7 @@ pub mod device_info;
 mod domain;
 mod providers;
 
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 use std::hash::Hash;
 use std::ops::Range;
 use std::time::Duration;
@@ -61,6 +61,48 @@ pub struct SuggestionRequest {
     /// The user agent of the request, including OS family, device form factor, and major Firefox
     /// version number.
     pub device_info: DeviceInfo,
+}
+
+/// A structure used to safely log the wrapped `SuggestionRequest`
+/// omitting the search query.
+pub struct DebugSuggestionRequest<'a> {
+    /// Whether or not to log the search query.
+    log_query: bool,
+
+    /// The wrapped `SuggestionRequest`.
+    wrapped_suggestion: &'a SuggestionRequest,
+}
+
+impl Debug for DebugSuggestionRequest<'_> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let empty_string = String::new();
+        fmt.debug_struct("SuggestionRequest")
+            .field("accepts_english", &self.wrapped_suggestion.accepts_english)
+            .field("city", &self.wrapped_suggestion.city)
+            .field("country", &self.wrapped_suggestion.country)
+            .field("device_info", &self.wrapped_suggestion.device_info)
+            .field("dma", &self.wrapped_suggestion.dma)
+            .field(
+                "query",
+                if self.log_query {
+                    &self.wrapped_suggestion.query
+                } else {
+                    &empty_string
+                },
+            )
+            .field("region", &self.wrapped_suggestion.region)
+            .finish()
+    }
+}
+
+impl SuggestionRequest {
+    /// Return an obect that knows how to debug-print a `SuggestionRequest`.
+    pub fn safe_debug(&self, log_query: bool) -> DebugSuggestionRequest<'_> {
+        DebugSuggestionRequest {
+            log_query,
+            wrapped_suggestion: self,
+        }
+    }
 }
 
 impl<'a, F> fake::Dummy<F> for SuggestionRequest {


### PR DESCRIPTION
While the object is always logged in the tracing logs, the log_full_request setting controls whether or not to log the query string as well or replace it with an empty string.

**Important note**: this PR additionally adds [`request`](https://github.com/mozilla-services/merino/blob/f3438bba90465f5b90812b99c4c4fe4604d1ae19/merino-web/src/endpoints/suggest.rs#L36) to the skip list of the tracing instrument, since the Http request would end up logging the raw query string from there.

With the option off (default):

```
 Oct 22 14:46:55.263  INFOmerino_adm::remote_settings: Completed syncing quicksuggest records from Remote Settings, type: "adm.remote-settings.sync-done"
    at merino-adm\src\remote_settings\mod.rs:192
    in merino_adm::remote_settings::sync
    in merino_web::providers::suggestion_provider_setup
    in merino_web::endpoints::suggest::suggest with query_parameters: Query(SuggestQueryParameters { client_variants: [], providers: None }), suggestion_request: SuggestionRequest { accepts_english: true, city: None, country: None, device_info: DeviceInfo { os_family: Windows, form_factor: Desktop, browser: Firefox(100) }, dma: None, query: "", region: None }
    in tracing_actix_web_mozlog::middleware::request with method: GET, path: /api/v1/suggest, rid: 8835f9df-8c53-418b-b0d7-9bc145e24315, agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:100.0) Gecko/20100101 Firefox/100.0"
```

With the option on:

```
  Oct 22 14:33:44.468  INFOmerino_adm::remote_settings: Completed syncing quicksuggest records from Remote Settings, type: "adm.remote-settings.sync-done"
    at merino-adm\src\remote_settings\mod.rs:192
    in merino_adm::remote_settings::sync
    in merino_web::providers::suggestion_provider_setup
    in merino_web::endpoints::suggest::suggest with query_parameters: Query(SuggestQueryParameters { client_variants: [], providers: None }), suggestion_request: SuggestionRequest { accepts_english: true, city: None, country: None, device_info: DeviceInfo { os_family: Windows, form_factor: Desktop, browser: Firefox(100) }, dma: None, query: "banana", region: None }
    in tracing_actix_web_mozlog::middleware::request with method: GET, path: /api/v1/suggest, rid: 1078df3e-9ad1-4294-8bcf-4df7fa8ae3ba, agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:100.0) Gecko/20100101 Firefox/100.0"
```

Fixes #171 