### PR TITLE
feat: initialize suggestion providers at start up [CONSVC-1247]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01260589f1aafad11224002741eb37bc603b4ce55b4e3556d2b2122f9aac7c51"
 dependencies = [
  "actix-codec 0.4.0",
- "actix-rt 2.2.0",
+ "actix-rt 2.3.0",
  "actix-service 2.0.0",
  "actix-tls 3.0.0-beta.5",
  "actix-utils 3.0.0",
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc7d7cd957c9ed92288a7c3c96af81fa5291f65247a76a34dac7b6af74e52ba0"
+checksum = "ea360596a50aa9af459850737f99293e5cb9114ae831118cb6026b3bbc7583ad"
 dependencies = [
  "actix-macros 0.2.1",
  "futures-core",
@@ -244,7 +244,7 @@ version = "2.0.0-beta.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26369215fcc3b0176018b3b68756a8bcc275bb000e6212e454944913a1f9bf87"
 dependencies = [
- "actix-rt 2.2.0",
+ "actix-rt 2.3.0",
  "actix-service 2.0.0",
  "actix-utils 3.0.0",
  "futures-core",
@@ -324,7 +324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65b7bb60840962ef0332f7ea01a57d73a24d2cb663708511ff800250bbfef569"
 dependencies = [
  "actix-codec 0.4.0",
- "actix-rt 2.2.0",
+ "actix-rt 2.3.0",
  "actix-service 2.0.0",
  "actix-utils 3.0.0",
  "derive_more",
@@ -413,7 +413,7 @@ dependencies = [
  "actix-http 3.0.0-beta.9",
  "actix-macros 0.2.1",
  "actix-router",
- "actix-rt 2.2.0",
+ "actix-rt 2.3.0",
  "actix-server 2.0.0-beta.5",
  "actix-service 2.0.0",
  "actix-utils 3.0.0",
@@ -2316,7 +2316,7 @@ checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 name = "merino"
 version = "0.3.0"
 dependencies = [
- "actix-rt 2.2.0",
+ "actix-rt 2.3.0",
  "anyhow",
  "cadence",
  "merino-settings",
@@ -2332,7 +2332,7 @@ dependencies = [
 name = "merino-adm"
 version = "0.3.0"
 dependencies = [
- "actix-rt 2.2.0",
+ "actix-rt 2.3.0",
  "anyhow",
  "async-trait",
  "deduped-dashmap",
@@ -2385,7 +2385,7 @@ dependencies = [
 name = "merino-integration-tests"
 version = "0.3.0"
 dependencies = [
- "actix-rt 2.2.0",
+ "actix-rt 2.3.0",
  "anyhow",
  "cadence",
  "crossbeam-channel",
@@ -2466,13 +2466,14 @@ name = "merino-web"
 version = "0.3.0"
 dependencies = [
  "actix-cors",
- "actix-rt 2.2.0",
+ "actix-rt 2.3.0",
  "actix-web 4.0.0-beta.8",
  "actix-web-location",
  "anyhow",
  "async-recursion",
  "backtrace",
  "cadence",
+ "futures",
  "futures-util",
  "lazy_static",
  "merino-adm",

--- a/merino-web/Cargo.toml
+++ b/merino-web/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.40"
 async-recursion = "0.3"
 backtrace = "0.3"
 cadence = "0.26"
+futures = "0.3"
 futures-util = "0.3"
 lazy_static = "1.4.0"
 merino-adm = { path = "../merino-adm" }


### PR DESCRIPTION
Moves initialization of suggestion providers to startup and shares the
initialized data between threads. Note, failing to initialize servers is
application fatal.

Closes #127