### PR TITLE
chore: update GitHub team name in Code Owners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 *                     @mozilla-services/context-services
-test-engineering/*    @mozilla-services/conserv-qa
+test-engineering/*    @mozilla-services/context-services-test-eng


### PR DESCRIPTION
I renamed the GitHub team name for test engineering to be more consistent with the Jira label and the parent team's name.
