### PR TITLE
fix: log sugestion request data with proper MozLog type information

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -28,7 +28,7 @@ the level and type of the log is listed.
   event will include fields for all relevant details of the request. **Fields:**
 
   - `query` - If query logging is enabled, the text the user typed. Otherwise
-    and empty string.
+    an empty string.
   - `country` - The country the request came from.
   - `region` - The first country subdivision the request came from.
   - `city` - The city the request came from.

--- a/docs/data.md
+++ b/docs/data.md
@@ -24,6 +24,31 @@ the level and type of the log is listed.
 
 ### `merino-web`
 
+- `INFO web.suggest.request` - A suggestion request is being processed. This
+  event will include fields for all relevant details of the request. **Fields:**
+
+  - `query` - If query logging is enabled, the text the user typed. Otherwise
+    and empty string.
+  - `country` - The country the request came from.
+  - `region` - The first country subdivision the request came from.
+  - `city` - The city the request came from.
+  - `dma` - A US-only location description that is larger than city and smaller
+    than states, but does not align to political borders.
+  - `agent` - The original user agent.
+  - `os_family` - Parsed from the user agent. One of "windows", "macos",
+    "linux", "ios", "android", "chrome os", "blackberry", or "other".
+  - `form_factor` - Parsed from the user agent. One of "desktop", "phone",
+    "tablet", or "other"
+  - `browser` - The browser and possibly version detected. Either "Firefox(XX)"
+    where XX is the version, or "Other".
+  - `rid` - The request ID.
+  - `accepts_english` - True if the user's Accept-Language header includes an
+    English locale, false otherwise.
+  - `requested_providers` - A comma separated list of providers requested via
+    the query string, or an empty string if none were requested (in which case
+    the default values would be used).
+  - `client_variants` - Any client variants sent to Merino in the query string.
+
 - `INFO web.configuring-suggesters` - A web worker is starting to configure
   local suggesters, which may take some seconds and require network traffic to
   synchronize data.

--- a/merino-integration-tests/src/utils/logging.rs
+++ b/merino-integration-tests/src/utils/logging.rs
@@ -27,6 +27,7 @@ pub struct LogWatcher {
 
 impl LogWatcher {
     /// Make a new LogWatcher with some events pre-populated. Primarily for testing LogWatcher itself.
+    #[must_use]
     pub fn with_events(events: Vec<TracingJsonEvent>) -> Self {
         Self {
             events,
@@ -52,6 +53,7 @@ impl LogWatcher {
     /// #
     /// // assert!(log_watcher.has(|msg| msg.field_contains("message", "request success")));
     /// ```
+    #[must_use = "LogWatcher::has does not make assertions alone, you probably want to wrap it in assert!()"]
     pub fn has<F>(&mut self, predicate: F) -> bool
     where
         F: FnMut(&TracingJsonEvent) -> bool,

--- a/merino-suggest/src/domain.rs
+++ b/merino-suggest/src/domain.rs
@@ -39,6 +39,7 @@ impl Proportion {
     }
 }
 
+/// Implement traits for a float type.
 macro_rules! impl_for_float {
     ($type: ty) => {
         impl TryFrom<$type> for Proportion {

--- a/merino-suggest/src/lib.rs
+++ b/merino-suggest/src/lib.rs
@@ -6,7 +6,7 @@ pub mod device_info;
 mod domain;
 mod providers;
 
-use std::fmt::{self, Debug};
+use std::fmt::Debug;
 use std::hash::Hash;
 use std::ops::Range;
 use std::time::Duration;
@@ -61,48 +61,6 @@ pub struct SuggestionRequest {
     /// The user agent of the request, including OS family, device form factor, and major Firefox
     /// version number.
     pub device_info: DeviceInfo,
-}
-
-/// A structure used to safely log the wrapped `SuggestionRequest`
-/// omitting the search query.
-pub struct DebugSuggestionRequest<'a> {
-    /// Whether or not to log the search query.
-    log_query: bool,
-
-    /// The wrapped `SuggestionRequest`.
-    wrapped_suggestion: &'a SuggestionRequest,
-}
-
-impl Debug for DebugSuggestionRequest<'_> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let empty_string = String::new();
-        fmt.debug_struct("SuggestionRequest")
-            .field("accepts_english", &self.wrapped_suggestion.accepts_english)
-            .field("city", &self.wrapped_suggestion.city)
-            .field("country", &self.wrapped_suggestion.country)
-            .field("device_info", &self.wrapped_suggestion.device_info)
-            .field("dma", &self.wrapped_suggestion.dma)
-            .field(
-                "query",
-                if self.log_query {
-                    &self.wrapped_suggestion.query
-                } else {
-                    &empty_string
-                },
-            )
-            .field("region", &self.wrapped_suggestion.region)
-            .finish()
-    }
-}
-
-impl SuggestionRequest {
-    /// Return an obect that knows how to debug-print a `SuggestionRequest`.
-    pub fn safe_debug(&self, log_query: bool) -> DebugSuggestionRequest<'_> {
-        DebugSuggestionRequest {
-            log_query,
-            wrapped_suggestion: self,
-        }
-    }
 }
 
 impl<'a, F> fake::Dummy<F> for SuggestionRequest {

--- a/merino-web/src/endpoints/suggest.rs
+++ b/merino-web/src/endpoints/suggest.rs
@@ -206,6 +206,7 @@ fn safe_log_request(
     );
 
     tracing::info!(
+        r#type = "web.suggest.request",
         accepts_english = ?request.accepts_english,
         %city,
         %country,
@@ -217,7 +218,9 @@ fn safe_log_request(
         %query,
         client_variants = %query_params.client_variants.join(","),
         %requested_providers,
-        r#type = "web.suggest.request",
+        // Also includes fields from tracing-actix-web-mozlog, including `rid`
+        // (request ID), `useragent` and `path` (which does not include query
+        // string).
         "handling suggestion request"
     );
 }

--- a/merino-web/src/endpoints/suggest.rs
+++ b/merino-web/src/endpoints/suggest.rs
@@ -13,7 +13,7 @@ use actix_web::{
 use anyhow::Result;
 use cadence::{CountedExt, Histogrammed, StatsdClient};
 use merino_settings::Settings;
-use merino_suggest::{Suggestion, SuggestionProvider};
+use merino_suggest::{Suggestion, SuggestionProvider, SuggestionRequest};
 use serde::{Deserialize, Serialize};
 use serde_with::{rust::StringWithSeparator, serde_as, CommaSeparator};
 use tracing_actix_web::RequestId;
@@ -26,10 +26,14 @@ pub fn configure(config: &mut ServiceConfig) {
 
 /// Suggest content in response to the queried text.
 #[get("")]
-#[tracing::instrument(
-    skip(metrics_client, suggestion_request, provider, request, settings),
-    fields(suggestion_request)
-)]
+#[tracing::instrument(skip(
+    metrics_client,
+    suggestion_request,
+    provider,
+    request,
+    settings,
+    query_parameters
+))]
 async fn suggest(
     SuggestionRequestWrapper(suggestion_request): SuggestionRequestWrapper,
     provider: Data<SuggestionProviderRef>,
@@ -38,9 +42,10 @@ async fn suggest(
     query_parameters: web::Query<SuggestQueryParameters>,
     request: HttpRequest,
 ) -> Result<HttpResponse, HandlerError> {
-    tracing::Span::current().record(
-        "suggestion_request",
-        &tracing::field::debug(&suggestion_request.safe_debug(settings.log_full_request)),
+    safe_log_request(
+        settings.log_full_request,
+        &suggestion_request,
+        &query_parameters,
     );
 
     let provider = provider
@@ -168,4 +173,51 @@ impl<'a> Serialize for SuggestionWrapper<'a> {
 
         generated.serialize(serializer)
     }
+}
+
+/// Log a suggestion request, respecting the log_query setting passed, and
+/// formatting all fields in a way that is helpful to our downstream log
+/// handlers. This primarily means that fields don't generate internal
+/// stringified JSON.
+fn safe_log_request(
+    log_query: bool,
+    request: &SuggestionRequest,
+    query_params: &SuggestQueryParameters,
+) {
+    let none = "none".to_string();
+    let country = request.country.as_ref().unwrap_or(&none);
+    let region = request.region.as_ref().unwrap_or(&none);
+    let city = request.city.as_ref().unwrap_or(&none);
+    let dma = request.dma.map_or_else(|| none.clone(), |v| v.to_string());
+    let query = if log_query {
+        request.query.as_str()
+    } else {
+        ""
+    };
+    let requested_providers = query_params.providers.as_ref().map_or_else(
+        || "".to_string(),
+        |ps| {
+            ps.iter()
+                .map(|p| p.as_str())
+                .collect::<Vec<_>>()
+                .as_slice()
+                .join(",")
+        },
+    );
+
+    tracing::info!(
+        accepts_english = ?request.accepts_english,
+        %city,
+        %country,
+        os_family = %request.device_info.os_family,
+        form_factory = %request.device_info.form_factor,
+        browser = %request.device_info.browser,
+        %dma,
+        %region,
+        %query,
+        client_variants = %query_params.client_variants.join(","),
+        %requested_providers,
+        r#type = "web.suggest.request",
+        "handling suggestion request"
+    );
 }


### PR DESCRIPTION
- test: make LogWatcher::has #[must_use], and fix a misuse of it
- fix: log sugestion request data with proper MozLog type information

Fixes #196
