### PR TITLE
feat: instrument cache hit and misses

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -117,11 +117,11 @@ the level and type of the log is listed.
 - `cache.memory.miss` - A counter that is incremented every time the in-memory
   cache is queried and a cached suggestion is not found.
 
-- `cache.memory.pointers_len` - A counter representing the number of entries in the
-  first level of hashing in the in-memory deduped hashmap.
+- `cache.memory.pointers-len` - A counter representing the number of entries in
+  the first level of hashing in the in-memory deduped hashmap.
 
-- `cache.memory.storage_len` - A counter representing the number of entries in the
-  second level of hashing in the in-memory deduped hashmap.
+- `cache.memory.storage-len` - A counter representing the number of entries in
+  the second level of hashing in the in-memory deduped hashmap.
 
 - `cache.redis.duration-us` - A histogram that records the amount of time, in
   microseconds, that the Redis cache took to provide a suggestion. Includes the
@@ -132,8 +132,8 @@ the level and type of the log is listed.
   - `cache-status` - If the response was pulled from the cache or regenerated.
     `"hit"`, `"miss"`, `"error"`, or `"none"`.
 
-- `cache.redis.hit` - A counter that is incremented every time the redis
-  cache is queried and a cached suggestion is found.
+- `cache.redis.hit` - A counter that is incremented every time the redis cache
+  is queried and a cached suggestion is found.
 
-- `cache.redis.miss` - A counter that is incremented every time the redis
-  cache is queried and a cached suggestion is not found.
+- `cache.redis.miss` - A counter that is incremented every time the redis cache
+  is queried and a cached suggestion is not found.

--- a/docs/data.md
+++ b/docs/data.md
@@ -117,11 +117,11 @@ the level and type of the log is listed.
 - `cache.memory.miss` - A counter that is incremented every time the in-memory
   cache is queried and a cached suggestion is not found.
 
-- `cache.memory.pointers-len` - A counter representing the number of entries in
+- `cache.memory.pointers-len` - A gauge representing the number of entries in
   the first level of hashing in the in-memory deduped hashmap.
 
-- `cache.memory.storage-len` - A counter representing the number of entries in
-  the second level of hashing in the in-memory deduped hashmap.
+- `cache.memory.storage-len` - A gauge representing the number of entries in the
+  second level of hashing in the in-memory deduped hashmap.
 
 - `cache.redis.duration-us` - A histogram that records the amount of time, in
   microseconds, that the Redis cache took to provide a suggestion. Includes the

--- a/docs/data.md
+++ b/docs/data.md
@@ -102,9 +102,6 @@ the level and type of the log is listed.
     accepted any `en-*` locale. Only requests that do are provided with
     suggestions.
 
-- `cache.memory.count` - A counter that records the number of cached items after
-  expired entries are purged.
-
 - `cache.memory.duration-us` - A histogram that records the amount of time, in
   microseconds, that the memory cache took to provide a suggestion. Includes the
   time it takes to fallback to the inner provider for cache misses and errors.

--- a/docs/data.md
+++ b/docs/data.md
@@ -128,3 +128,9 @@ the level and type of the log is listed.
 
   - `cache-status` - If the response was pulled from the cache or regenerated.
     `"hit"`, `"miss"`, `"error"`, or `"none"`.
+
+- `cache.redis.hit` - A counter that is incremented every time the redis
+  cache is queried and a cached suggestion is found.
+
+- `cache.redis.miss` - A counter that is incremented every time the redis
+  cache is queried and a cached suggestion is not found.

--- a/docs/data.md
+++ b/docs/data.md
@@ -120,6 +120,12 @@ the level and type of the log is listed.
 - `cache.memory.miss` - A counter that is incremented every time the in-memory
   cache is queried and a cached suggestion is not found.
 
+- `cache.memory.pointers_len` - A counter representing the number of entries in the
+  first level of hashing in the in-memory deduped hashmap.
+
+- `cache.memory.storage_len` - A counter representing the number of entries in the
+  second level of hashing in the in-memory deduped hashmap.
+
 - `cache.redis.duration-us` - A histogram that records the amount of time, in
   microseconds, that the Redis cache took to provide a suggestion. Includes the
   time it takes to fallback to the inner provider for cache misses and errors.

--- a/docs/data.md
+++ b/docs/data.md
@@ -102,6 +102,9 @@ the level and type of the log is listed.
     accepted any `en-*` locale. Only requests that do are provided with
     suggestions.
 
+- `cache.memory.count` - A counter that records the number of cached items after
+  expired entries are purged.
+
 - `cache.memory.duration-us` - A histogram that records the amount of time, in
   microseconds, that the memory cache took to provide a suggestion. Includes the
   time it takes to fallback to the inner provider for cache misses and errors.
@@ -110,6 +113,12 @@ the level and type of the log is listed.
 
   - `cache-status` - If the response was pulled from the cache or regenerated.
     `"hit"`, `"miss"`, `"error"`, or `"none"`.
+
+- `cache.memory.hit` - A counter that is incremented every time the in-memory
+  cache is queried and a cached suggestion is found.
+
+- `cache.memory.miss` - A counter that is incremented every time the in-memory
+  cache is queried and a cached suggestion is not found.
 
 - `cache.redis.duration-us` - A histogram that records the amount of time, in
   microseconds, that the Redis cache took to provide a suggestion. Includes the

--- a/merino-cache/src/memory.rs
+++ b/merino-cache/src/memory.rs
@@ -7,7 +7,7 @@
 
 use anyhow::anyhow;
 use async_trait::async_trait;
-use cadence::{Counted, CountedExt, Histogrammed, StatsdClient};
+use cadence::{CountedExt, Gauged, Histogrammed, StatsdClient};
 use deduped_dashmap::{ControlFlow, DedupedMap};
 use lazy_static::lazy_static;
 use merino_settings::providers::MemoryCacheConfig;
@@ -178,10 +178,10 @@ impl Suggester {
         );
 
         metrics_client
-            .count("cache.memory.storage_len", items.len_storage() as i64)
+            .gauge("cache.memory.storage-len", items.len_storage() as u64)
             .ok();
         metrics_client
-            .count("cache.memory.pointers_len", items.len_pointers() as i64)
+            .gauge("cache.memory.pointers-len", items.len_pointers() as u64)
             .ok();
     }
 }

--- a/merino-cache/src/memory.rs
+++ b/merino-cache/src/memory.rs
@@ -329,8 +329,9 @@ mod tests {
             .take(2)
             .map(|x| String::from_utf8(x).unwrap())
             .collect();
-        assert!(collected_data.contains(&"merino-test.cache.memory.storage_len:1|c".to_string()));
-        assert!(collected_data.contains(&"merino-test.cache.memory.pointers_len:1|c".to_string()));
+        dbg!(&collected_data);
+        assert!(collected_data.contains(&"merino-test.cache.memory.storage-len:1|g".to_string()));
+        assert!(collected_data.contains(&"merino-test.cache.memory.pointers-len:1|g".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
**Note: this is based on #205 and will need to be rebased after that gets merged.**

This additionally adds a metric to track the number of items in the in-memory cache. Note that this does not add the same count of items for the Redis cache, as it's slightly more involved there and I'd take it as a separate, specific PR.

This contributes toward #207 , but follow-up work is required to fix it.