### PR TITLE
form_factor field name typo in logs

### DIFF
--- a/merino-web/src/endpoints/suggest.rs
+++ b/merino-web/src/endpoints/suggest.rs
@@ -200,7 +200,7 @@ fn safe_log_request(
         %city,
         %country,
         os_family = %request.device_info.os_family,
-        form_factory = %request.device_info.form_factor,
+        form_factor = %request.device_info.form_factor,
         browser = %request.device_info.browser,
         %dma,
         %region,


### PR DESCRIPTION
Discovered this while investigating nonprod logging in scope of
https://mozilla-hub.atlassian.net/browse/SVCSE-138