### PR TITLE
fix(adm): Include `/v1` on the end of the remote settings URL we give to the RS client

### DIFF
--- a/config/test.yaml
+++ b/config/test.yaml
@@ -9,7 +9,7 @@ redis:
 
 remote_settings:
   # This is the docker-compose provided server, in ./dev/.
-  server: "http://localhost:8888"
+  server: http://localhost:8888
 
 metrics:
   sink_host: "0.0.0.0"

--- a/merino-adm/src/remote_settings/mod.rs
+++ b/merino-adm/src/remote_settings/mod.rs
@@ -57,7 +57,7 @@ impl RemoteSettingsSuggester {
                     .unwrap_or(&settings.remote_settings.default_collection)
                     .clone(),
             )
-            .server_url(&settings.remote_settings.server)
+            .server_url(&format!("{}/v1", settings.remote_settings.server))
             .sync_if_empty(true)
             .storage(Box::new(remote_settings_client::client::FileStorage {
                 folder: std::env::temp_dir(),


### PR DESCRIPTION
The default value that remote-settings-client uses for the server includes the /v1 suffix, but ours doesn't. Add it back in so that we don't confuse the client.
