### PR TITLE
test: Fix intermittent failures with ReqwestClient

### DIFF
--- a/merino-adm/src/remote_settings/mod.rs
+++ b/merino-adm/src/remote_settings/mod.rs
@@ -42,6 +42,9 @@ impl RemoteSettingsSuggester {
         config: &RemoteSettingsConfig,
         metrics_client: StatsdClient,
     ) -> Result<Box<Self>, SetupError> {
+        let reqwest_client = ReqwestClient::try_new()
+            .context("Unable to create the Reqwest client")
+            .map_err(SetupError::Network)?;
         let mut remote_settings_client = remote_settings_client::Client::builder()
             .bucket_name(
                 config
@@ -63,7 +66,7 @@ impl RemoteSettingsSuggester {
                 folder: std::env::temp_dir(),
                 ..remote_settings_client::client::FileStorage::default()
             }))
-            .http_client(Box::new(ReqwestClient::new()))
+            .http_client(Box::new(reqwest_client))
             .build()
             .context("Unable to initialize the Remote Settings client")
             .map_err(SetupError::InvalidConfiguration)?;

--- a/merino-adm/src/remote_settings/reqwest_client.rs
+++ b/merino-adm/src/remote_settings/reqwest_client.rs
@@ -44,8 +44,8 @@ impl RsRequester for ReqwestClient {
             Err(e) => {
                 tracing::error!(
                     r#type = "adm.remote-settings.reqwest.get-failed",
-                    "ReqwestClient - unable to submit GET request. {:?}",
-                    e.to_string()
+                    "ReqwestClient - unable to submit GET request. {:#?}",
+                    e
                 );
                 Err(())
             }
@@ -61,8 +61,8 @@ impl RsRequester for ReqwestClient {
                 let body = response.bytes().await.map_err(|err| {
                     tracing::error!(
                         r#type = "adm.remote-settings.reqwest.parsing-failed",
-                        "ReqwestClient - unable to parse response body. {:?}",
-                        err.to_string()
+                        "ReqwestClient - unable to parse response body. {:#?}",
+                        err
                     );
                 })?;
 

--- a/merino-adm/src/remote_settings/reqwest_client.rs
+++ b/merino-adm/src/remote_settings/reqwest_client.rs
@@ -4,7 +4,7 @@
 
 //! An HTTP client implementation to use with the remote-settings-client.
 
-use anyhow::Context;
+use anyhow::{Context, Error};
 use async_trait::async_trait;
 use remote_settings_client::client::net::{
     Headers as RsHeaders, Requester as RsRequester, Response as RsResponse, Url as RsUrl,
@@ -20,10 +20,13 @@ pub struct ReqwestClient {
 
 impl ReqwestClient {
     /// Instantiate a new Reqwest client to perform HTTP requests.
-    pub fn new() -> ReqwestClient {
-        Self {
-            reqwest_client: reqwest::Client::new(),
-        }
+    pub fn try_new() -> Result<ReqwestClient, Error> {
+        let reqwest_client = reqwest::Client::builder()
+            // Disable the connection pool to avoid the IncompleteMessage errors.
+            // See #259 for more details.
+            .pool_max_idle_per_host(0)
+            .build()?;
+        Ok(Self { reqwest_client })
     }
 }
 


### PR DESCRIPTION
This fixes #259.

The issue was caused by the connection pool in Reqwest/Hyper. See more details in [here](https://github.com/hyperium/hyper/issues/2136#issuecomment-589345238).

Since `ReqwestClient` is only used by RS suggester, and it is not making constant network calls to RS. Disabling the connection pool should not be a big deal, but I will let @mythmon @Dexterp37 decide if this is acceptable or shall we keep it as is and add the retry to the API.