### PR TITLE
Debug issue with RS client 🚧

### DIFF
--- a/config/ci.yaml
+++ b/config/ci.yaml
@@ -19,8 +19,14 @@ logging:
 
 # The suggestion providers to enable
 suggestion_providers:
-  test:
+  test_wiki_fruit:
     type: "wiki_fruit"
+  test_remote_settings:
+    type: memory_cache
+    inner:
+      type: remote_settings
+      collection: quicksuggest
+      suggestion_score: 0.3
 
 sentry:
   mode: "disabled"

--- a/test-engineering/contract-tests/client/tests/conftest.py
+++ b/test-engineering/contract-tests/client/tests/conftest.py
@@ -2,28 +2,83 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import json
 import os
 import pathlib
+from functools import lru_cache
+from typing import Dict
 
+import pytest
+import requests
 import yaml
-from models import Scenario
+from models import KintoSuggestion, Scenario
+
+REQUIRED_OPTIONS = (
+    "scenarios_file",
+    "merino_url",
+    "kinto_url",
+    "kinto_bucket",
+    "kinto_collection",
+    "kinto_data_dir",
+    "kinto_attachments_url",
+)
+
+
+@pytest.fixture(scope="session", name="kinto_icon_urls")
+def fixture_kinto_icon_urls(request) -> Dict[str, str]:
+    """Return a map from suggestion title to icon URL."""
+
+    api = f"{request.config.option.kinto_url}/v1"
+    bucket = f"{api}/buckets/{request.config.option.kinto_bucket}"
+    collection = f"{bucket}/collections/{request.config.option.kinto_collection}"
+    attachments_url = request.config.option.kinto_attachments_url
+
+    @lru_cache(maxsize=None)
+    def fetch_icon_url(*, record_id: str) -> str:
+        """Fetch the icon URL for the given Kinto record ID from Kinto."""
+        record_url = f"{collection}/records/{record_id}"
+
+        response = requests.get(record_url)
+        response.raise_for_status()
+
+        icon_location = response.json()["data"]["attachment"]["location"]
+
+        return f"{attachments_url}/{icon_location}"
+
+    return {
+        suggestion.title: fetch_icon_url(record_id=f"icon-{suggestion.icon}")
+        for suggestion in request.config.kinto_suggestions
+    }
 
 
 def pytest_configure(config):
-    """Load test scenarios from file."""
+    """Load data for tests and store it on config."""
 
-    scenarios_file = os.environ["SCENARIOS_FILE"]
+    for option_name in REQUIRED_OPTIONS:
+        if getattr(config.option, option_name) is None:
+            raise pytest.UsageError(f"Required option '{option_name}' is not set.")
 
-    with pathlib.Path(scenarios_file).open() as f:
+    with pathlib.Path(config.option.scenarios_file).open() as f:
         loaded_scenarios = yaml.safe_load(f)
 
     config.merino_scenarios = [
         Scenario(**scenario) for scenario in loaded_scenarios["scenarios"]
     ]
 
+    kinto_data_dir = pathlib.Path(config.option.kinto_data_dir)
+
+    config.kinto_suggestions = [
+        KintoSuggestion(**suggestion_data)
+        for data_file in kinto_data_dir.glob("*.json")
+        for suggestion_data in json.loads(data_file.read_text())
+    ]
+
 
 def pytest_generate_tests(metafunc):
     """Generate tests from the loaded test scenarios."""
+
+    if "steps" not in metafunc.fixturenames:
+        return
 
     ids = []
     argvalues = []
@@ -37,6 +92,17 @@ def pytest_generate_tests(metafunc):
 
 def pytest_addoption(parser):
     """Define custom CLI options."""
+    parser.addoption(
+        "--scenarios_file",
+        action="store",
+        dest="scenarios_file",
+        help="File with test scenarios",
+        metavar="SCENARIOS_FILE",
+        default=os.environ.get("SCENARIOS_FILE"),
+        type=str,
+        required=False,
+    )
+
     merino_group = parser.getgroup("merino")
     merino_group.addoption(
         "--merino-url",
@@ -45,6 +111,58 @@ def pytest_addoption(parser):
         help="Merino endpoint URL",
         metavar="MERINO_URL",
         default=os.environ.get("MERINO_URL"),
+        type=str,
+        required=False,
+    )
+
+    kinto_group = parser.getgroup("kinto")
+    kinto_group.addoption(
+        "--kinto-url",
+        action="store",
+        dest="kinto_url",
+        help="Kinto URL",
+        metavar="KINTO_URL",
+        default=os.environ.get("KINTO_URL"),
+        type=str,
+        required=False,
+    )
+    kinto_group.addoption(
+        "--kinto-bucket",
+        action="store",
+        dest="kinto_bucket",
+        help="Kinto bucket",
+        metavar="KINTO_BUCKET",
+        default=os.environ.get("KINTO_BUCKET"),
+        type=str,
+        required=False,
+    )
+    kinto_group.addoption(
+        "--kinto-collection",
+        action="store",
+        dest="kinto_collection",
+        help="Kinto collection",
+        metavar="KINTO_COLLECTION",
+        default=os.environ.get("KINTO_COLLECTION"),
+        type=str,
+        required=False,
+    )
+    kinto_group.addoption(
+        "--kinto-data-dir",
+        action="store",
+        dest="kinto_data_dir",
+        help="Directory containing Kinto data",
+        metavar="KINTO_DATA_DIR",
+        default=os.environ.get("KINTO_DATA_DIR"),
+        type=str,
+        required=False,
+    )
+    kinto_group.addoption(
+        "--kinto-attachments-url",
+        action="store",
+        dest="kinto_attachments_url",
+        help="Kinto attachments URL",
+        metavar="KINTO_ATTACHMENTS_URL",
+        default=os.environ.get("KINTO_ATTACHMENTS_URL"),
         type=str,
         required=False,
     )

--- a/test-engineering/contract-tests/client/tests/models.py
+++ b/test-engineering/contract-tests/client/tests/models.py
@@ -69,3 +69,17 @@ class Scenario(BaseModel):
     name: str
     description: str
     steps: List[Step]
+
+
+class KintoSuggestion(BaseModel):
+    """Class that holds information about a Suggestion in Kinto."""
+
+    id: int
+    url: str
+    click_url: str
+    impression_url: str
+    iab_category: str
+    icon: str
+    advertiser: str
+    title: str
+    keywords: List[str] = Field(default_factory=list)

--- a/test-engineering/contract-tests/client/tests/models.py
+++ b/test-engineering/contract-tests/client/tests/models.py
@@ -35,8 +35,8 @@ class Suggestion(BaseModel, extra=Extra.allow):
     provider: str
     advertiser: str
     is_sponsored: bool
-    icon: str
     score: float
+    icon: Optional[str] = Field(...)
 
 
 class ResponseContent(BaseModel):

--- a/test-engineering/contract-tests/client/tests/test_merino.py
+++ b/test-engineering/contract-tests/client/tests/test_merino.py
@@ -3,23 +3,78 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-from typing import List
+from typing import Dict, List, Set, Tuple
 
 import pytest
 import requests
-from models import ResponseContent, Step
+from models import ResponseContent, Step, Suggestion
 
-# A set of model fields that we do not want to include in the Python dict representation
-EXCLUDED_FIELDS = {"request_id"}
+# We need to exclude the following fields on the response level:
+# The request ID is dynamic in nature and the value cannot be validated here.
+# The suggestions are validated separately in a different step.
+CONTENT_EXCLUDE: Set[str] = {"request_id", "suggestions"}
+
+# We need to exclude the following field on the suggestion level:
+# The icon URL for RS suggestions is dynamic in nature and handed to Merino by
+# Kinto. We validate that in a seperate step.
+SUGGESTION_EXCLUDE: Set[str] = {"icon"}
 
 
-@pytest.fixture(name="merino_url")
-def fixture_merino_url(request):
+@pytest.fixture(scope="session", name="merino_url")
+def fixture_merino_url(request) -> str:
     """Read the merino URL from the pytest config."""
     return request.config.option.merino_url
 
 
-def test_merino(merino_url: str, steps: List[Step]):
+def suggestion_id(suggestion: Suggestion) -> Tuple:
+    """Return the values for the fields that identify a suggestion."""
+    return suggestion.provider, suggestion.block_id
+
+
+def assert_200_response(
+    *,
+    step_content: ResponseContent,
+    merino_content: ResponseContent,
+    kinto_icon_urls: Dict[str, str],
+) -> None:
+    """Check that the content for a 200 OK response is what we expect."""
+
+    expected_content_dict = step_content.dict(exclude=CONTENT_EXCLUDE)
+    merino_content_dict = merino_content.dict(exclude=CONTENT_EXCLUDE)
+    assert expected_content_dict == merino_content_dict
+
+    # The order of suggestions in Merino's response is not guaranteed.
+    # Sort them by ('provider', 'block_id') before validating them.
+    sorted_merino_suggestions = [
+        suggestion.dict(exclude=SUGGESTION_EXCLUDE)
+        for suggestion in sorted(merino_content.suggestions, key=suggestion_id)
+    ]
+    sorted_expected_suggestions = [
+        suggestion.dict(exclude=SUGGESTION_EXCLUDE)
+        for suggestion in sorted(step_content.suggestions, key=suggestion_id)
+    ]
+    assert sorted_merino_suggestions == sorted_expected_suggestions
+
+    # This is for selecting the right expected suggestion for a given Merino
+    # suggestion based on the ('provider', 'block_id') fields.
+    expected_suggestions_by_id = {
+        suggestion_id(suggestion): suggestion for suggestion in step_content.suggestions
+    }
+
+    for suggestion in merino_content.suggestions:
+        if "remote_settings" in suggestion.provider:
+            # The icon URL is not static for RS suggestions
+            assert suggestion.icon == kinto_icon_urls[suggestion.title]
+            continue
+
+        if "wiki_fruit" in suggestion.provider:
+            # The icon URL is static for WikiFruit suggestions
+            expected_suggestion = expected_suggestions_by_id[suggestion_id(suggestion)]
+            assert suggestion.icon == expected_suggestion.icon
+            continue
+
+
+def test_merino(merino_url: str, steps: List[Step], kinto_icon_urls: Dict[str, str]):
     """Test for requesting suggestions from Merino."""
 
     for step in steps:
@@ -41,18 +96,17 @@ def test_merino(merino_url: str, steps: List[Step]):
         assert r.status_code == step.response.status_code, error_message
 
         if r.status_code == 200:
-            # If the response status code is 200 OK, create a pydantic model
-            # instance for validating the response content from Merino. Then
-            # generate a dict representation of the model and compare it with
-            # the expected response content for this step in the test scenario.
-            merino_response_content = ResponseContent(**r.json()).dict(
-                exclude=EXCLUDED_FIELDS,
+            # If the response status code is 200 OK, use the
+            # assert_200_response() helper function to validate the content of
+            # the response from Merino. This includes creating a pydantic model
+            # instance for checking the field types and comparing a dict
+            # representation of the model instance with the expected response
+            # content for this step in the test scenario.
+            assert_200_response(
+                step_content=step.response.content,
+                merino_content=ResponseContent(**r.json()),
+                kinto_icon_urls=kinto_icon_urls,
             )
-            step_response_content = step.response.content.dict(
-                exclude=EXCLUDED_FIELDS,
-            )
-            assert merino_response_content == step_response_content
-
             continue
 
         if r.status_code == 204:

--- a/test-engineering/contract-tests/docker-compose.yml
+++ b/test-engineering/contract-tests/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     environment:
       KINTO_INI: /etc/kinto.ini
       # We need to overwrite the following setting for contract-tests
-      KINTO_ATTACHMENT_EXTRA_BASE_URL: http://kinto-attachments:80
+      KINTO_ATTACHMENT_EXTRA_BASE_URL: http://kinto-attachments:80/
 
   kinto-attachments:
     image: httpd

--- a/test-engineering/contract-tests/docker-compose.yml
+++ b/test-engineering/contract-tests/docker-compose.yml
@@ -8,6 +8,9 @@ services:
     environment:
       # The configuration preset to use
       MERINO_ENV: "ci"
+      MERINO_REMOTE_SETTINGS__DEFAULT_BUCKET: main
+      MERINO_REMOTE_SETTINGS__DEFAULT_COLLECTION: quicksuggest
+      MERINO_REMOTE_SETTINGS__SERVER: http://kinto:8888
     depends_on:
       - kinto
       - kinto-attachments
@@ -21,14 +24,18 @@ services:
     container_name: merino_client
     depends_on:
       - merino
-      - kinto
-      - kinto-attachments
     volumes:
       - ./volumes/client:/tmp/client
+      - ./volumes/kinto:/tmp/kinto
       - ../../dev/wait-for-it.sh:/wait-for-it.sh
     environment:
       MERINO_URL: http://merino:8000
       SCENARIOS_FILE: /tmp/client/scenarios.yml
+      KINTO_URL: http://kinto:8888
+      KINTO_BUCKET: main
+      KINTO_COLLECTION: quicksuggest
+      KINTO_DATA_DIR: /tmp/kinto
+      KINTO_ATTACHMENTS_URL: http://kinto-attachments
     command: >
       /wait-for-it.sh merino:8000 --strict -- pytest -vv
 

--- a/test-engineering/contract-tests/docker-compose.yml
+++ b/test-engineering/contract-tests/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       KINTO_BUCKET: main
       KINTO_COLLECTION: quicksuggest
       KINTO_DATA_DIR: /tmp/kinto
-      KINTO_ATTACHMENTS_URL: http://kinto-attachments
+      KINTO_ATTACHMENTS_URL: http://kinto-attachments:80
     command: >
       /wait-for-it.sh merino:8000 --strict -- pytest -vv
 

--- a/test-engineering/contract-tests/docker-compose.yml
+++ b/test-engineering/contract-tests/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       - kinto-setup
     volumes:
       - ../../dev:/tmp/dev
+    command: >
+      sh -c 'sleep 10 && /app/bin/merino'
 
   client:
     image: client

--- a/test-engineering/contract-tests/volumes/client/scenarios.yml
+++ b/test-engineering/contract-tests/volumes/client/scenarios.yml
@@ -26,7 +26,7 @@ scenarios:
                 url: 'https://en.wikipedia.org/wiki/Apple'
                 impression_url: 'https://127.0.0.1/'
                 click_url: 'https://127.0.0.1/'
-                provider: 'test'
+                provider: 'test_wiki_fruit'
                 advertiser: 'test_advertiser'
                 is_sponsored: false
                 icon: 'https://en.wikipedia.org/favicon.ico'
@@ -58,37 +58,7 @@ scenarios:
                 url: 'https://en.wikipedia.org/wiki/Apple'
                 impression_url: 'https://127.0.0.1/'
                 click_url: 'https://127.0.0.1/'
-                provider: 'test'
-                advertiser: 'test_advertiser'
-                is_sponsored: false
-                icon: 'https://en.wikipedia.org/favicon.ico'
-                score: 0.0
-
-  - name: wiki_fruit__banana
-    description: Test that Merino successfully returns a WikiFruit suggestion
-    steps:
-      - request:
-          method: GET
-          path: '/api/v1/suggest?q=banana'
-          headers:
-            - name: User-Agent
-              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
-            - name: Accept-Language
-              value: 'en-US'
-        response:
-          status_code: 200
-          content:
-            client_variants: []
-            server_variants: []
-            request_id: null
-            suggestions:
-              - block_id: 1
-                full_keyword: 'banana'
-                title: 'Wikipedia - Banana'
-                url: 'https://en.wikipedia.org/wiki/Banana'
-                impression_url: 'https://127.0.0.1/'
-                click_url: 'https://127.0.0.1/'
-                provider: 'test'
+                provider: 'test_wiki_fruit'
                 advertiser: 'test_advertiser'
                 is_sponsored: false
                 icon: 'https://en.wikipedia.org/favicon.ico'
@@ -118,8 +88,80 @@ scenarios:
                 url: 'https://en.wikipedia.org/wiki/Cherry'
                 impression_url: 'https://127.0.0.1/'
                 click_url: 'https://127.0.0.1/'
-                provider: 'test'
+                provider: 'test_wiki_fruit'
                 advertiser: 'test_advertiser'
                 is_sponsored: false
                 icon: 'https://en.wikipedia.org/favicon.ico'
                 score: 0.0
+
+  - name: remote_settings__coffee
+    description: Test that Merino successfully returns a Remote Settings suggestion
+    steps:
+      - request:
+          method: GET
+          path: '/api/v1/suggest?q=coffee'
+          headers:
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+            - name: Accept-Language
+              value: 'en-US'
+        response:
+          status_code: 200
+          content:
+            client_variants: []
+            server_variants: []
+            request_id: null
+            suggestions:
+              - block_id: 3
+                full_keyword: 'coffee'
+                title: 'Coffee'
+                url: 'https://example.com/target/coffee'
+                impression_url: 'https://example.com/impression/coffee'
+                click_url: 'https://example.com/click/coffee'
+                provider: 'test_remote_settings'
+                advertiser: 'Example.com'
+                is_sponsored: true
+                # The client test framework knows how to interpret a value of `null` for this field.
+                icon: null
+                score: 0.3
+
+  - name: multiple_providers__banana
+    description: Test that Merino successfully returns suggestions from multiple providers
+    steps:
+      - request:
+          method: GET
+          path: '/api/v1/suggest?q=banana'
+          headers:
+            - name: User-Agent
+              value: 'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/91.0'
+            - name: Accept-Language
+              value: 'en-US'
+        response:
+          status_code: 200
+          content:
+            client_variants: []
+            server_variants: []
+            request_id: null
+            suggestions:
+              - block_id: 1
+                full_keyword: 'banana'
+                title: 'Wikipedia - Banana'
+                url: 'https://en.wikipedia.org/wiki/Banana'
+                impression_url: 'https://127.0.0.1/'
+                click_url: 'https://127.0.0.1/'
+                provider: 'test_wiki_fruit'
+                advertiser: 'test_advertiser'
+                is_sponsored: false
+                icon: https://en.wikipedia.org/favicon.ico
+                score: 0.0
+              - block_id: 2
+                full_keyword: 'banana'
+                title: 'Banana'
+                url: 'https://example.org/target/banana'
+                impression_url: 'https://example.org/impression/banana'
+                click_url: 'https://example.org/click/banana'
+                provider: 'test_remote_settings'
+                advertiser: 'Example.org'
+                is_sponsored: true
+                icon: null
+                score: 0.3

--- a/test-engineering/load-tests/docker-compose.yml
+++ b/test-engineering/load-tests/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     container_name: locust_merino
     build: ../..
     environment:
+      # TODO: This needs to be updated or kinto needs to be added
       MERINO_ENV: "ci"
     volumes:
       - ../../dev:/tmp/dev
@@ -16,7 +17,7 @@ services:
     depends_on:
       - merino
     ports:
-     - "8089:8089"
+      - "8089:8089"
     environment:
       # Set environment variables, see https://docs.locust.io/en/stable/configuration.html#environment-variables
       LOCUST_HOST: http://merino:8000
@@ -27,7 +28,7 @@ services:
     image: locust
     build: .
     depends_on:
-    - merino
+      - merino
     environment:
       # Set environment variables, see https://docs.locust.io/en/stable/configuration.html#environment-variables
       LOCUST_MASTER_NODE_HOST: locust_master


### PR DESCRIPTION
This pull requests adds the test-eng changes for adding contract tests for the RS provider from #267 but without the commit to revert back to our custom RS client implementation (8c94c8085cefd7e6e4f780acbcc5dc36cc8225b3).

The purpose of this branch is to diagnose the issues we're seeing with Merino not returning any suggestions from RS when using the RS client crate. This is expected to fail on CI. 🤖 

You can run these tests locally from the Merino repository root as follows:

Build the Docker images:

```text
docker-compose -f test-engineering/contract-tests/docker-compose.yml build
```

Run the tests:

```text
docker-compose -f test-engineering/contract-tests/docker-compose.yml up --abort-on-container-exit
```

When making code changes, make sure to rebuild the respective Docker images before running `up`, for example:

```text
docker-compose -f test-engineering/contract-tests/docker-compose.yml build merino
```

You can change the logging level for Merino by updating the level in `config/ci.yaml`, for example:

```yaml
logging:
  # Print logs in a verbose, formatted format
  format: pretty
  # The minimum level that logs should be reported at
  levels: ["TRACE"]
```


