### PR TITLE
feat: check signature of remote-settings content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3358,8 +3358,8 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remote-settings-client"
-version = "0.1.0"
-source = "git+https://github.com/mozilla-services/remote-settings-client?tag=v1.0.0#6bb0b0d1f0a9243ffe4a58d81f682ba721e226f2"
+version = "1.0.1"
+source = "git+https://github.com/mozilla-services/remote-settings-client?tag=v1.0.1#457c94b201bb62e7b6c2dc727ce1be78b5fe1e0c"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2463,6 +2463,8 @@ dependencies = [
  "radix_trie",
  "remote-settings-client",
  "reqwest 0.11.4",
+ "sentry",
+ "sentry-anyhow",
  "serde 1.0.126",
  "serde_derive",
  "serde_json",
@@ -3366,6 +3368,8 @@ dependencies = [
  "derive_builder",
  "hex",
  "log",
+ "oid-registry",
+ "ring",
  "serde 1.0.126",
  "serde_json",
  "thiserror",
@@ -3462,6 +3466,21 @@ checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "hostname",
  "quick-error 1.2.3",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3920,6 +3939,12 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "standback"
@@ -4554,6 +4579,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"

--- a/merino-adm/Cargo.toml
+++ b/merino-adm/Cargo.toml
@@ -25,7 +25,7 @@ serde_with = "1.9"
 thiserror = "1.0"
 tokio = { version = "1.8.2", features = ["rt", "macros", "rt-multi-thread"] }
 tracing = "0.1.29"
-remote-settings-client = { tag = "v1.0.0", git = "https://github.com/mozilla-services/remote-settings-client", features=["ring_verifier"] }
+remote-settings-client = { tag = "v1.0.1", git = "https://github.com/mozilla-services/remote-settings-client", features=["ring_verifier"] }
 
 [dependencies.sentry]
 # Pin Sentry to 0.19 until our on premise Sentry server upgrades to at least 20.6

--- a/merino-adm/Cargo.toml
+++ b/merino-adm/Cargo.toml
@@ -15,6 +15,8 @@ merino-settings = { path = "../merino-settings" }
 merino-suggest = { path = "../merino-suggest" }
 radix_trie = "0.2.1"
 reqwest = { version = "0.11.3", features = ["json"] }
+# Pin sentry_anyhow to 0.19 until our on-premise server updates to 20.6.
+sentry-anyhow = "0.19"
 serde = { version = "1.0.125", features = ["rc"] }
 serde_derive = "1.0.125"
 serde_json = "1.0.64"
@@ -23,7 +25,13 @@ serde_with = "1.9"
 thiserror = "1.0"
 tokio = { version = "1.8.2", features = ["rt", "macros", "rt-multi-thread"] }
 tracing = "0.1.29"
-remote-settings-client = { tag = "v1.0.0", git = "https://github.com/mozilla-services/remote-settings-client" }
+remote-settings-client = { tag = "v1.0.0", git = "https://github.com/mozilla-services/remote-settings-client", features=["ring_verifier"] }
+
+[dependencies.sentry]
+# Pin Sentry to 0.19 until our on premise Sentry server upgrades to at least 20.6
+version = "0.19"
+default_features = false
+features = ["backtrace", "contexts", "panic", "transport", "anyhow"]
 
 [dev-dependencies]
 actix-rt = "2.2"

--- a/merino-adm/src/remote_settings/mod.rs
+++ b/merino-adm/src/remote_settings/mod.rs
@@ -1,8 +1,10 @@
 //! AdM integration that uses the remote-settings provided data.
 
 mod reqwest_client;
+mod soft_verifier;
 
 use crate::remote_settings::reqwest_client::ReqwestClient;
+use crate::remote_settings::soft_verifier::SoftVerifier;
 use anyhow::Context;
 use async_trait::async_trait;
 use cadence::StatsdClient;
@@ -27,7 +29,7 @@ pub struct RemoteSettingsSuggester {
     /// A map from keywords to suggestions that can be provided.
     suggestions: Arc<DedupedMap<String, (), Suggestion>>,
 
-    /// A map from keywords to suggestions that can be provided.
+    /// The Statsd client used to record statistics.
     metrics_client: StatsdClient,
 }
 
@@ -67,6 +69,7 @@ impl RemoteSettingsSuggester {
                 ..remote_settings_client::client::FileStorage::default()
             }))
             .http_client(Box::new(reqwest_client))
+            .verifier(Box::new(SoftVerifier::new()))
             .build()
             .context("Unable to initialize the Remote Settings client")
             .map_err(SetupError::InvalidConfiguration)?;

--- a/merino-adm/src/remote_settings/soft_verifier.rs
+++ b/merino-adm/src/remote_settings/soft_verifier.rs
@@ -1,0 +1,91 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! A custom signature verifier implementation that marks the verification
+//! as successful even in case of problems, but logs a warning about the
+//! failure.
+
+use anyhow::Context;
+use async_trait::async_trait;
+use remote_settings_client::{
+    client::net::Requester, Collection, RingVerifier, SignatureError, Verification,
+};
+use sentry_anyhow::capture_anyhow;
+
+/// A custom signature verification helper to use with the
+/// remote-settings-client library.
+pub struct SoftVerifier {
+    /// The wrapped RingVerifier.
+    inner: RingVerifier,
+}
+
+impl SoftVerifier {
+    /// Instantiate a new signature verifier.
+    pub fn new() -> Self {
+        SoftVerifier {
+            inner: RingVerifier {},
+        }
+    }
+}
+
+#[async_trait]
+impl Verification for SoftVerifier {
+    fn verify_nist384p_chain(
+        &self,
+        epoch_seconds: u64,
+        pem_bytes: &[u8],
+        root_hash: &str,
+        subject_cn: &str,
+        message: &[u8],
+        signature: &[u8],
+    ) -> Result<(), SignatureError> {
+        self.inner
+            .verify_nist384p_chain(
+                epoch_seconds,
+                pem_bytes,
+                root_hash,
+                subject_cn,
+                message,
+                signature,
+            )
+            .context("nist384p verification for Remote Settings")
+            .or_else(|e| {
+                tracing::error!(
+                    r#type = "adm.remote-settings.soft-verifier.verify_nist384p_chain",
+                    "nist384p chain verification failed. {:#?}",
+                    e
+                );
+                capture_anyhow(&e);
+                Ok(())
+            })
+    }
+
+    async fn verify(
+        &self,
+        requester: &Box<dyn Requester + 'static>,
+        collection: &Collection,
+        root_hash: &str,
+    ) -> Result<(), SignatureError> {
+        self.inner
+            .verify(requester, collection, root_hash)
+            .await
+            .context("Signature verification for Remote Settings")
+            .or_else(|e| {
+                tracing::error!(
+                    r#type = "adm.remote-settings.soft-verifier.verify",
+                    "Verification failed. {:#?}",
+                    e
+                );
+                capture_anyhow(&e);
+                Ok(())
+            })
+    }
+
+    fn verify_sha256_hash(&self, content: &[u8], expected: &[u8]) -> Result<(), SignatureError> {
+        // We don't need to catch errors on this one: this method is not used
+        // for signature verification, but just for verifying the integrity of
+        // the downloaded attachments.
+        self.inner.verify_sha256_hash(content, expected)
+    }
+}


### PR DESCRIPTION
this implements a new signature verifier that performs the signature verification on content coming from remote settings
but exclusively logs errors, still allowing to use any oddly signed content.

Note: you can already verify that this is correctly working since tests don't specify the proper x5u field and so verification is failing (and printing a log).

Fixes #218
Fixes #264 