### PR TITLE
refactor(memory-cache): Offload the cache expiry task to the blocking threads

### DIFF
--- a/merino-cache/Cargo.toml
+++ b/merino-cache/Cargo.toml
@@ -17,7 +17,7 @@ merino-suggest = { path = "../merino-suggest" }
 redis = { version = "^0.20", features = ["tokio-comp", "connection-manager"] }
 serde = "^1"
 serde_json = "^1"
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["time", "rt"] }
 tracing = { version = "0.1", features = ["async-await"] }
 tracing-futures = "^0.2"
 uuid = "0.8"

--- a/merino-cache/src/memory.rs
+++ b/merino-cache/src/memory.rs
@@ -139,7 +139,8 @@ impl Suggester {
                     // is allowed to run.
                     let _ = tokio::task::spawn_blocking(move || {
                         cache.remove_expired_entries();
-                    }).await;
+                    })
+                    .await;
                 }
             });
         }

--- a/merino-cache/src/memory.rs
+++ b/merino-cache/src/memory.rs
@@ -128,14 +128,14 @@ impl Suggester {
                 timer.tick().await;
                 loop {
                     timer.tick().await;
-                    let mut suggester = cloned_suggester.clone();
+                    let mut cache = cloned_suggester.clone();
 
                     // Dispatch the expiry task to the blocking threads of the
                     // runtime. This prevents the expiry task, which is inherently
                     // blocking, from blocking the other tasks running on the
                     // core threads of the runtime.
                     tokio::task::spawn_blocking(move || {
-                        suggester.remove_expired_entries();
+                        cache.remove_expired_entries();
                     });
                 }
             });

--- a/merino-cache/src/memory.rs
+++ b/merino-cache/src/memory.rs
@@ -134,9 +134,12 @@ impl Suggester {
                     // runtime. This prevents the expiry task, which is inherently
                     // blocking, from blocking the other tasks running on the
                     // core threads of the runtime.
-                    tokio::task::spawn_blocking(move || {
+                    //
+                    // Wait for the task to finish so that only one expiry task
+                    // is allowed to run.
+                    let _ = tokio::task::spawn_blocking(move || {
                         cache.remove_expired_entries();
-                    });
+                    }).await;
                 }
             });
         }

--- a/merino-cache/src/memory.rs
+++ b/merino-cache/src/memory.rs
@@ -118,7 +118,7 @@ impl Suggester {
         };
 
         {
-            let mut cloned_suggester = suggester.clone();
+            let cloned_suggester = suggester.clone();
             let task_interval = config.cleanup_interval;
             tokio::spawn(async move {
                 let mut timer = tokio::time::interval(task_interval);
@@ -128,7 +128,15 @@ impl Suggester {
                 timer.tick().await;
                 loop {
                     timer.tick().await;
-                    cloned_suggester.remove_expired_entries();
+                    let mut suggester = cloned_suggester.clone();
+
+                    // Dispatch the expiry task to the blocking threads of the
+                    // runtime. This prevents the expiry task, which is inherently
+                    // blocking, from blocking the other tasks running on the
+                    // core threads of the runtime.
+                    tokio::task::spawn_blocking(move || {
+                        suggester.remove_expired_entries();
+                    });
                 }
             });
         }


### PR DESCRIPTION
While Merino uses the "max-removal-entries" to throttle the cache expiry job, it will still prevent other tasks, scheduled on the same thread, from running because those lock acquisitions of the underlying cache stores are inherently blocking. As a result, it might increase the response latency for those affected requests.

Cache cleanup is not of the highest priority and can be done in the background, offloading the expiry task to the blocking threads of the runtime could help smooth those latency spikes.