### PR TITLE
Remove compression features from actix-web

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "actix-codec"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13895df506faee81e423febbae3a33b27fca71831b96bb3d60adf16ebcfea952"
+checksum = "a36c014a3e811624313b51a227b775ecba55d36ef9462bbaac7d4f13e54c9271"
 dependencies = [
  "bitflags",
  "bytes 1.0.1",
@@ -15,7 +15,7 @@ dependencies = [
  "log",
  "memchr",
  "pin-project-lite 0.2.7",
- "tokio 1.9.0",
+ "tokio 1.15.0",
  "tokio-util 0.6.7",
 ]
 
@@ -48,19 +48,17 @@ dependencies = [
  "ahash",
  "base64",
  "bitflags",
- "brotli2",
  "bytes 1.0.1",
  "bytestring",
  "derive_more",
  "encoding_rs",
- "flate2",
  "futures-core",
  "futures-task",
- "h2 0.3.9",
+ "h2 0.3.10",
  "http",
  "httparse",
  "httpdate 1.0.1",
- "itoa",
+ "itoa 0.4.7",
  "language-tags",
  "local-channel",
  "log",
@@ -70,7 +68,6 @@ dependencies = [
  "rand 0.8.4",
  "sha-1",
  "smallvec",
- "zstd",
 ]
 
 [[package]]
@@ -85,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "actix-router"
-version = "0.5.0-beta.3"
+version = "0.5.0-beta.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd9f117b910fbcce6e9f45092ffd4ff017785a346d09e2d4fd049f4e20384f4"
+checksum = "b53c1deabdbf3a8a8b9a949123edd3cafb873abd75da96b5933a8b590f9d6dc2"
 dependencies = [
  "bytestring",
  "firestorm",
@@ -99,20 +96,20 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c2f80ce8d0c990941c7a7a931f69fd0701b76d521f8d36298edf59cd3fbf1f"
+checksum = "82cf33e04d9911b39bfb7be3c01309568b4315895d3358372dce64ed2c2bf32d"
 dependencies = [
  "actix-macros",
  "futures-core",
- "tokio 1.9.0",
+ "tokio 1.15.0",
 ]
 
 [[package]]
 name = "actix-server"
-version = "2.0.0-rc.1"
+version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c9b22794b8af1c2e02434873ef858f2a7db40dbbf861ce77a04cd81ac6b767"
+checksum = "c9259b4f3cc9ca96d7d91a7da66b7b01c47653a0da5b0ba3f7f45a344480443b"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -123,7 +120,7 @@ dependencies = [
  "mio 0.8.0",
  "num_cpus",
  "socket2 0.4.2",
- "tokio 1.9.0",
+ "tokio 1.15.0",
 ]
 
 [[package]]
@@ -165,12 +162,11 @@ dependencies = [
  "ahash",
  "bytes 1.0.1",
  "cfg-if 1.0.0",
- "cookie",
  "derive_more",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "itoa",
+ "itoa 0.4.7",
  "language-tags",
  "log",
  "mime",
@@ -189,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web-codegen"
-version = "0.5.0-beta.6"
+version = "0.5.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a90b7f6c2fde9a1fe3df4da758c2c3c9d620dfa3eae4da0b6925dc0a13444a"
+checksum = "98a793e4a7bd059e06e1bc1bd9943b57a47f806de3599d2437441682292c333e"
 dependencies = [
  "actix-router",
  "proc-macro2",
@@ -201,11 +197,10 @@ dependencies = [
 
 [[package]]
 name = "actix-web-location"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86828387b71a4b577d36f50d91d0158980c3b89780cfbde8aa3d424887fefe66"
+checksum = "5ac1ad06d03f1930726ab2ef962fd8bda324791263101242588da3afdb8a3cf3"
 dependencies = [
- "actix-http",
  "actix-web",
  "anyhow",
  "async-trait",
@@ -529,12 +524,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base-x"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
-
-[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,26 +608,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4445dea95f4c2b41cde57cc9fee236ae4dbae88d8fcbdb4750fc1bb5d86aaecd"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "brotli2"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb036c3eade309815c15ddbacec5b22c4d1f3983a774ab2eac2e3e9ea85568e"
-dependencies = [
- "brotli-sys",
- "libc",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,9 +673,6 @@ name = "cc"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cfg-if"
@@ -744,7 +710,7 @@ dependencies = [
  "futures-util",
  "memchr",
  "pin-project-lite 0.2.7",
- "tokio 1.9.0",
+ "tokio 1.15.0",
 ]
 
 [[package]]
@@ -773,12 +739,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f92cfa0fd5690b3cf8c1ef2cabbd9b7ef22fa53cf5e1f92b05103f6d5d1cf6e7"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,17 +749,6 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "cookie"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf8865bac3d9a3bde5bde9088ca431b11f5d37c7a578b8086af77248b76627"
-dependencies = [
- "percent-encoding",
- "time 0.2.27",
- "version_check",
-]
 
 [[package]]
 name = "core-foundation"
@@ -824,15 +773,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
-dependencies = [
- "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1033,7 +973,7 @@ dependencies = [
  "config",
  "num_cpus",
  "serde 1.0.126",
- "tokio 1.9.0",
+ "tokio 1.15.0",
 ]
 
 [[package]]
@@ -1165,12 +1105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
-
-[[package]]
 name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "firestorm"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31586bda1b136406162e381a3185a506cdfc1631708dd40cba2f6628d8634499"
+checksum = "4d3d6188b8804df28032815ea256b6955c9625c24da7525f387a7af02fbb8f01"
 
 [[package]]
 name = "fix-hidden-lifetime-bug"
@@ -1295,18 +1229,6 @@ name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
-
-[[package]]
-name = "flate2"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
-dependencies = [
- "cfg-if 1.0.0",
- "crc32fast",
- "libc",
- "miniz_oxide",
-]
 
 [[package]]
 name = "fnv"
@@ -1547,9 +1469,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f072413d126e57991455e0a922b31e4c8ba7c2ffbebf6b78b4f8521397d65cd"
+checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
@@ -1559,7 +1481,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.9.0",
+ "tokio 1.15.0",
  "tokio-util 0.6.7",
  "tracing",
 ]
@@ -1598,13 +1520,13 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
+checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
- "itoa",
+ "itoa 1.0.1",
 ]
 
 [[package]]
@@ -1670,7 +1592,7 @@ dependencies = [
  "serde 1.0.126",
  "serde_json",
  "serde_regex",
- "tokio 1.9.0",
+ "tokio 1.15.0",
 ]
 
 [[package]]
@@ -1688,7 +1610,7 @@ dependencies = [
  "http-body 0.3.1",
  "httparse",
  "httpdate 0.3.2",
- "itoa",
+ "itoa 0.4.7",
  "pin-project",
  "socket2 0.3.19",
  "tokio 0.2.25",
@@ -1707,15 +1629,15 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.9",
+ "h2 0.3.10",
  "http",
  "http-body 0.4.2",
  "httparse",
  "httpdate 1.0.1",
- "itoa",
+ "itoa 0.4.7",
  "pin-project-lite 0.2.7",
  "socket2 0.4.2",
- "tokio 1.9.0",
+ "tokio 1.15.0",
  "tower-service",
  "tracing",
  "want",
@@ -1743,7 +1665,7 @@ dependencies = [
  "bytes 1.0.1",
  "hyper 0.14.10",
  "native-tls",
- "tokio 1.9.0",
+ "tokio 1.15.0",
  "tokio-native-tls",
 ]
 
@@ -1854,13 +1776,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
-name = "jobserver"
-version = "0.1.22"
+name = "itoa"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
-dependencies = [
- "libc",
-]
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
@@ -2112,7 +2031,7 @@ dependencies = [
  "serde_qs",
  "serde_with",
  "thiserror",
- "tokio 1.9.0",
+ "tokio 1.15.0",
  "tracing",
 ]
 
@@ -2136,7 +2055,7 @@ dependencies = [
  "redis",
  "serde 1.0.126",
  "serde_json",
- "tokio 1.9.0",
+ "tokio 1.15.0",
  "tracing",
  "tracing-futures",
  "uuid",
@@ -2165,7 +2084,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "statsd-parser",
- "tokio 1.9.0",
+ "tokio 1.15.0",
  "tokio-test",
  "tracing",
  "tracing-futures",
@@ -2220,7 +2139,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "thiserror",
- "tokio 1.9.0",
+ "tokio 1.15.0",
  "uuid",
 ]
 
@@ -2250,7 +2169,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "thiserror",
- "tokio 1.9.0",
+ "tokio 1.15.0",
  "tokio-test",
  "tracing",
  "tracing-actix-web",
@@ -2926,11 +2845,11 @@ dependencies = [
  "dtoa",
  "futures",
  "futures-util",
- "itoa",
+ "itoa 0.4.7",
  "percent-encoding",
  "pin-project-lite 0.2.7",
  "sha1",
- "tokio 1.9.0",
+ "tokio 1.15.0",
  "tokio-util 0.6.7",
  "url",
 ]
@@ -3073,7 +2992,7 @@ dependencies = [
  "serde 1.0.126",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.9.0",
+ "tokio 1.15.0",
  "tokio-native-tls",
  "url",
  "wasm-bindgen",
@@ -3377,7 +3296,7 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
- "itoa",
+ "itoa 0.4.7",
  "ryu",
  "serde 1.0.126",
 ]
@@ -3419,7 +3338,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 0.4.7",
  "ryu",
  "serde 1.0.126",
 ]
@@ -3561,15 +3480,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "standback"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3580,55 +3490,6 @@ name = "statsd-parser"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad8f85387840bde2a5ee7d4d0ee9cb035334fdb9ed6b51ad5277063e4b7bef8f"
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version 0.2.3",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde 1.0.126",
- "serde_derive",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde 1.0.126",
- "serde_derive",
- "serde_json",
- "sha1",
- "syn",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "string_cache"
@@ -3743,50 +3604,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
-dependencies = [
- "const_fn",
- "libc",
- "standback",
- "stdweb",
- "time-macros",
- "version_check",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "time"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41effe7cfa8af36f439fac33861b66b049edc6f9a32331e2312660529c1c24ad"
 dependencies = [
- "itoa",
+ "itoa 0.4.7",
  "libc",
-]
-
-[[package]]
-name = "time-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
-dependencies = [
- "proc-macro-hack",
- "time-macros-impl",
-]
-
-[[package]]
-name = "time-macros-impl"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "standback",
- "syn",
 ]
 
 [[package]]
@@ -3833,11 +3656,10 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.9.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
+checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
 dependencies = [
- "autocfg",
  "bytes 1.0.1",
  "libc",
  "memchr",
@@ -3853,9 +3675,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.3.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3869,7 +3691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
- "tokio 1.9.0",
+ "tokio 1.15.0",
 ]
 
 [[package]]
@@ -3880,7 +3702,7 @@ checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.7",
- "tokio 1.9.0",
+ "tokio 1.15.0",
 ]
 
 [[package]]
@@ -3892,7 +3714,7 @@ dependencies = [
  "async-stream",
  "bytes 1.0.1",
  "futures-core",
- "tokio 1.9.0",
+ "tokio 1.15.0",
  "tokio-stream",
 ]
 
@@ -3931,7 +3753,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.2.7",
- "tokio 1.9.0",
+ "tokio 1.15.0",
 ]
 
 [[package]]
@@ -3977,12 +3799,10 @@ dependencies = [
 
 [[package]]
 name = "tracing-actix-web-mozlog"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2959308510680ddc89913e2d0081d8cb6ed90286be8e6ef801d6c17480f65160"
+checksum = "c7a48241994954294d4c704f89d87e3fbc9605566093b339ebdbaa6484c4b53c"
 dependencies = [
- "actix-http",
- "actix-service",
  "actix-web",
  "chrono",
  "futures-util",
@@ -4408,33 +4228,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
-]
-
-[[package]]
-name = "zstd"
-version = "0.9.0+zstd.1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07749a5dc2cb6b36661290245e350f15ec3bbb304e493db54a1d354480522ccd"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "4.1.1+zstd.1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91c90f2c593b003603e5e0493c837088df4469da25aafff8bce42ba48caf079"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "1.6.1+zstd.1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615120c7a2431d16cf1cf979e7fc31ba7a5b5e5707b29c8a99e5dbf8a8392a33"
-dependencies = [
- "cc",
- "libc",
 ]

--- a/merino-suggest/Cargo.toml
+++ b/merino-suggest/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.5.1"
 edition = "2018"
 
 [dependencies]
-actix-web = "=4.0.0-beta.15"
+actix-web = { version = "=4.0.0-beta.15", default_features = false }
 anyhow = "1.0"
 async-trait = "0.1"
 blake3 = "1"

--- a/merino-web/Cargo.toml
+++ b/merino-web/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2018"
 [dependencies]
 actix-cors = "0.6.0-beta.7"
 actix-rt = "2.3"
-actix-web = "=4.0.0-beta.15"
-actix-web-location = { version = "0.5.0", features = ["maxmind", "actix-web-v4", "cadence"] }
+actix-web-location = { version = "0.5.1", features = ["maxmind", "actix-web-v4", "cadence"] }
 anyhow = "1.0.40"
 async-recursion = "0.3"
 backtrace = "0.3"
@@ -28,11 +27,22 @@ thiserror = "1.0.24"
 tokio = { version = "1.8.2", features = ["sync"] }
 tokio-test = "0.4.1"
 tracing = { version = "0.1.29", features = ["async-await"] }
-tracing-actix-web-mozlog = "0.4.0"
+tracing-actix-web-mozlog = "0.4.1"
 tracing-futures = "0.2"
 tracing-actix-web = "0.5.0-beta.6"
 uuid = "0.8.2"
 woothee = "0.11.0"
+
+[dependencies.actix-web]
+version = "=4.0.0-beta.15"
+# Relative to default:
+# - Disable compression features, because Nginx handles compression for us
+#   - compress-zstd
+#   - compress-brotli
+#   - compress-gzip
+# - Disable `cookies` because Merino doesn't use cookiees
+default_features = false
+features = []
 
 [dependencies.sentry]
 # Pin Sentry to 0.19 until our on premise Sentry server upgrades to at least 20.6

--- a/merino/Cargo.toml
+++ b/merino/Cargo.toml
@@ -12,7 +12,7 @@ cadence = "0.26"
 merino-settings = { path = "../merino-settings" }
 merino-web = { path = "../merino-web" }
 tracing = "0.1.29"
-tracing-actix-web-mozlog = "0.4.0"
+tracing-actix-web-mozlog = "0.4.1"
 tracing-log = "0.1.2"
 tracing-subscriber = { version = "0.2.18", features = ["registry", "env-filter"] }
 


### PR DESCRIPTION
refactor(web): Disable compression related features in actix-web

Nginx handles compression for us, and these features (especially zstd) add
significant compile time. On my machine a clean release compilation went from
90 seconds with zstd to 65 seconds without.