### PR TITLE
refactor(settings): Split suggestion provider configuration from main settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
- "ahash",
+ "ahash 0.7.4",
  "base64",
  "bitflags",
  "bytes 1.0.1",
@@ -66,7 +66,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite 0.2.7",
  "rand 0.8.4",
- "sha-1",
+ "sha-1 0.9.6",
  "smallvec",
 ]
 
@@ -91,7 +91,7 @@ dependencies = [
  "http",
  "log",
  "regex",
- "serde 1.0.126",
+ "serde",
 ]
 
 [[package]]
@@ -159,7 +159,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "actix-web-codegen",
- "ahash",
+ "ahash 0.7.4",
  "bytes 1.0.1",
  "cfg-if 1.0.0",
  "derive_more",
@@ -174,7 +174,7 @@ dependencies = [
  "paste",
  "pin-project-lite 0.2.7",
  "regex",
- "serde 1.0.126",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "smallvec",
@@ -225,6 +225,12 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "ahash"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
 name = "ahash"
@@ -300,7 +306,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f1c3703dd33532d7f0ca049168930e9099ecac238e23cf932f3a69c42f06da"
 dependencies = [
- "serde 1.0.126",
+ "serde",
  "serde_json",
 ]
 
@@ -581,7 +587,19 @@ dependencies = [
  "cc",
  "cfg-if 1.0.0",
  "constant_time_eq",
- "digest",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.12.4",
 ]
 
 [[package]]
@@ -590,7 +608,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
 ]
 
 [[package]]
@@ -612,6 +639,12 @@ name = "bumpalo"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -663,10 +696,16 @@ checksum = "64f464b27d56e99fb36031754bb17fe97f1a69f66621628f002664cee6a4bcbf"
 dependencies = [
  "hex",
  "regex",
- "serde 1.0.126",
+ "serde",
  "serde_json",
  "thiserror",
 ]
+
+[[package]]
+name = "castaway"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
@@ -694,8 +733,8 @@ checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
  "libc",
  "num-integer",
- "num-traits 0.2.14",
- "serde 1.0.126",
+ "num-traits",
+ "serde",
  "time 0.1.43",
  "winapi 0.3.9",
 ]
@@ -730,9 +769,22 @@ checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
 dependencies = [
  "lazy_static",
  "nom 5.1.2",
+ "serde",
+]
+
+[[package]]
+name = "config"
+version = "0.11.0"
+source = "git+https://github.com/mehcode/config-rs?branch=master#53e43fbcf96b5c2a661d052a6e3d55fc3709f1e1"
+dependencies = [
+ "async-trait",
+ "json5",
+ "lazy_static",
+ "nom 7.1.0",
+ "pathdiff",
+ "ron",
  "rust-ini",
- "serde 1.0.126",
- "serde-hjson",
+ "serde",
  "serde_json",
  "toml",
  "yaml-rust",
@@ -970,9 +1022,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6284d3fbd2821de00878c70e55e89859c3115c4cacbd63a8dbd56887e88d069f"
 dependencies = [
  "async-trait",
- "config",
+ "config 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus",
- "serde 1.0.126",
+ "serde",
  "tokio 1.15.0",
 ]
 
@@ -982,7 +1034,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91cf5a8c2f2097e2a32627123508635d47ce10563d999ec1a95addf08b502ba"
 dependencies = [
- "serde 1.0.126",
+ "serde",
  "uuid",
 ]
 
@@ -1001,7 +1053,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c73af209b6a5dc8ca7cbaba720732304792cddc933cfea3d74509c2b1ef2f436"
 dependencies = [
  "num-bigint",
- "num-traits 0.2.14",
+ "num-traits",
  "syn",
 ]
 
@@ -1014,7 +1066,7 @@ dependencies = [
  "der-oid-macro",
  "nom 7.1.0",
  "num-bigint",
- "num-traits 0.2.14",
+ "num-traits",
  "rusticata-macros",
 ]
 
@@ -1076,11 +1128,20 @@ checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -1102,6 +1163,15 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68df3f2b690c1b86e65ef7830956aededf3cb0a16f898f79b9a6f421a7b6211b"
+dependencies = [
+ "rand 0.8.4",
 ]
 
 [[package]]
@@ -1188,6 +1258,12 @@ dependencies = [
  "dummy",
  "rand 0.8.4",
 ]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fastrand"
@@ -1388,6 +1464,15 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
@@ -1484,6 +1569,15 @@ dependencies = [
  "tokio 1.15.0",
  "tokio-util 0.6.7",
  "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash 0.4.7",
 ]
 
 [[package]]
@@ -1589,10 +1683,38 @@ dependencies = [
  "log",
  "qstring",
  "regex",
- "serde 1.0.126",
+ "serde",
  "serde_json",
  "serde_regex",
  "tokio 1.15.0",
+]
+
+[[package]]
+name = "httpmock"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c159c4fc205e6c1a9b325cb7ec135d13b5f47188ce175dabb76ec847f331d9bd"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-trait",
+ "base64",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper 0.14.10",
+ "isahc",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio 1.15.0",
+ "url",
 ]
 
 [[package]]
@@ -1707,7 +1829,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -1736,11 +1858,12 @@ checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "isahc"
-version = "1.4.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81c01404730bb4574bbacb59ca0855f969f8eabd688ca22866f2cc333f1a4f69"
+checksum = "d140e84730d325378912ede32d7cd53ef1542725503b3353e5ec8113c7c6f588"
 dependencies = [
  "async-channel",
+ "castaway",
  "crossbeam-utils",
  "curl",
  "curl-sys",
@@ -1788,6 +1911,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json5"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d993b17585f39e5e3bd98ff52bbd9e2a6d6b3f5b09d8abcec9d1873fb04cf3f"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
 ]
 
 [[package]]
@@ -1978,7 +2112,7 @@ checksum = "835288c768ea07fedcccf84f1c9a463fe7e36856b5868d5ea050f858e20b01b8"
 dependencies = [
  "log",
  "memchr",
- "serde 1.0.126",
+ "serde",
 ]
 
 [[package]]
@@ -2015,7 +2149,7 @@ dependencies = [
  "fake",
  "futures",
  "http",
- "httpmock",
+ "httpmock 0.5.8",
  "lazy_static",
  "merino-settings",
  "merino-suggest",
@@ -2025,7 +2159,7 @@ dependencies = [
  "reqwest 0.11.4",
  "sentry",
  "sentry-anyhow",
- "serde 1.0.126",
+ "serde",
  "serde_derive",
  "serde_json",
  "serde_qs",
@@ -2053,7 +2187,7 @@ dependencies = [
  "merino-suggest",
  "proptest",
  "redis",
- "serde 1.0.126",
+ "serde",
  "serde_json",
  "tokio 1.15.0",
  "tracing",
@@ -2070,7 +2204,7 @@ dependencies = [
  "cadence",
  "crossbeam-channel",
  "deadpool",
- "httpmock",
+ "httpmock 0.5.8",
  "lazy_static",
  "maplit",
  "merino-integration-tests-macro",
@@ -2080,7 +2214,7 @@ dependencies = [
  "pretty_assertions",
  "redis",
  "reqwest 0.11.4",
- "serde 1.0.126",
+ "serde",
  "serde_json",
  "serde_with",
  "statsd-parser",
@@ -2107,15 +2241,19 @@ name = "merino-settings"
 version = "0.5.1"
 dependencies = [
  "anyhow",
- "config",
+ "async-trait",
+ "config 0.11.0 (git+https://github.com/mehcode/config-rs?branch=master)",
  "http",
+ "httpmock 0.6.6",
  "parameterized",
  "redis",
+ "reqwest 0.11.4",
  "sentry",
- "serde 1.0.126",
+ "serde",
  "serde_json",
  "serde_path_to_error",
  "serde_with",
+ "tokio 1.15.0",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2135,7 +2273,7 @@ dependencies = [
  "merino-settings",
  "rand 0.8.4",
  "regex",
- "serde 1.0.126",
+ "serde",
  "serde_json",
  "serde_with",
  "thiserror",
@@ -2165,7 +2303,7 @@ dependencies = [
  "pretty_assertions",
  "sentry",
  "sentry-backtrace",
- "serde 1.0.126",
+ "serde",
  "serde_json",
  "serde_with",
  "thiserror",
@@ -2360,7 +2498,7 @@ checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -2370,16 +2508,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
- "num-traits 0.2.14",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-dependencies = [
- "num-traits 0.2.14",
+ "num-traits",
 ]
 
 [[package]]
@@ -2427,6 +2556,12 @@ checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
@@ -2462,6 +2597,16 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "ordered-multimap"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c672c7ad9ec066e428c00eb917124a06f08db19e2584de982cc34b1f4c12485"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.9.1",
 ]
 
 [[package]]
@@ -2532,6 +2677,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,6 +2695,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 dependencies = [
  "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+dependencies = [
+ "maplit",
+ "pest",
+ "sha-1 0.8.2",
 ]
 
 [[package]]
@@ -2683,7 +2868,7 @@ dependencies = [
  "bitflags",
  "byteorder",
  "lazy_static",
- "num-traits 0.2.14",
+ "num-traits",
  "quick-error 2.0.1",
  "rand 0.8.4",
  "rand_chacha 0.3.1",
@@ -2913,7 +3098,7 @@ dependencies = [
  "log",
  "oid-registry",
  "ring",
- "serde 1.0.126",
+ "serde",
  "serde_json",
  "thiserror",
  "url",
@@ -2953,7 +3138,7 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite 0.2.7",
- "serde 1.0.126",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio 0.2.25",
@@ -2989,7 +3174,7 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite 0.2.7",
- "serde 1.0.126",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio 1.15.0",
@@ -3017,10 +3202,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-ini"
-version = "0.13.0"
+name = "ron"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e52c148ef37f8c375d49d5a73aa70713125b7f19095948a923f80afdeb22ec2"
+checksum = "1b861ecaade43ac97886a512b360d01d66be9f41f3c61088b42cedf92e03d678"
+dependencies = [
+ "base64",
+ "bitflags",
+ "serde",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63471c4aa97a1cf8332a5f97709a79a4234698de6a1f5087faf66f2dae810e22"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ordered-multimap",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -3245,7 +3445,7 @@ checksum = "87b41bac48a3586249431fa9efb88cd1414c3455117eb57c02f5bda9634e158d"
 dependencies = [
  "chrono",
  "debugid",
- "serde 1.0.126",
+ "serde",
  "serde_json",
  "thiserror",
  "url",
@@ -3254,29 +3454,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
-
-[[package]]
-name = "serde"
 version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-hjson"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a3a4e0ea8a88553209f6cc6cfe8724ecad22e1acf372793c27d995290fe74f8"
-dependencies = [
- "lazy_static",
- "num-traits 0.1.43",
- "regex",
- "serde 0.8.23",
 ]
 
 [[package]]
@@ -3298,7 +3480,7 @@ checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa 0.4.7",
  "ryu",
- "serde 1.0.126",
+ "serde",
 ]
 
 [[package]]
@@ -3307,7 +3489,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f6109f0506e20f7e0f910e51a0079acf41da8e0694e6442527c4ddf5a2b158"
 dependencies = [
- "serde 1.0.126",
+ "serde",
 ]
 
 [[package]]
@@ -3317,7 +3499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a72808528a89fa9eca23bbb6a1eb92cb639b881357269b6510f11e50c0f8a9"
 dependencies = [
  "percent-encoding",
- "serde 1.0.126",
+ "serde",
  "thiserror",
 ]
 
@@ -3328,7 +3510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
 dependencies = [
  "regex",
- "serde 1.0.126",
+ "serde",
 ]
 
 [[package]]
@@ -3340,7 +3522,7 @@ dependencies = [
  "form_urlencoded",
  "itoa 0.4.7",
  "ryu",
- "serde 1.0.126",
+ "serde",
 ]
 
 [[package]]
@@ -3350,7 +3532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad9fdbb69badc8916db738c25efd04f0a65297d26c2f8de4b62e57b8c12bc72"
 dependencies = [
  "rustversion",
- "serde 1.0.126",
+ "serde",
  "serde_with_macros",
 ]
 
@@ -3368,15 +3550,27 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha-1"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c4cfa741c5832d0ef7fab46cabed29c2aae926db0b11bb2069edd8db5e64e16"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest",
- "opaque-debug",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -3412,6 +3606,12 @@ checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
 
 [[package]]
 name = "siphasher"
@@ -3762,7 +3962,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "serde 1.0.126",
+ "serde",
 ]
 
 [[package]]
@@ -3807,7 +4007,7 @@ dependencies = [
  "chrono",
  "futures-util",
  "gethostname",
- "serde 1.0.126",
+ "serde",
  "serde_json",
  "tracing",
  "tracing-actix-web",
@@ -3836,7 +4036,7 @@ dependencies = [
  "chrono",
  "gethostname",
  "log",
- "serde 1.0.126",
+ "serde",
  "serde_json",
  "tracing",
  "tracing-core",
@@ -3880,7 +4080,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
 dependencies = [
- "serde 1.0.126",
+ "serde",
  "tracing-core",
 ]
 
@@ -3895,7 +4095,7 @@ dependencies = [
  "lazy_static",
  "matchers",
  "regex",
- "serde 1.0.126",
+ "serde",
  "serde_json",
  "sharded-slab",
  "smallvec",
@@ -3982,7 +4182,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
- "serde 1.0.126",
+ "serde",
 ]
 
 [[package]]
@@ -3992,7 +4192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom 0.2.3",
- "serde 1.0.126",
+ "serde",
 ]
 
 [[package]]
@@ -4061,7 +4261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
  "cfg-if 1.0.0",
- "serde 1.0.126",
+ "serde",
  "serde_json",
  "wasm-bindgen-macro",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,7 +775,7 @@ dependencies = [
 [[package]]
 name = "config"
 version = "0.11.0"
-source = "git+https://github.com/mehcode/config-rs?branch=master#53e43fbcf96b5c2a661d052a6e3d55fc3709f1e1"
+source = "git+https://github.com/mehcode/config-rs?rev=53e43fb#53e43fbcf96b5c2a661d052a6e3d55fc3709f1e1"
 dependencies = [
  "async-trait",
  "json5",
@@ -2242,7 +2242,7 @@ version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
- "config 0.11.0 (git+https://github.com/mehcode/config-rs?branch=master)",
+ "config 0.11.0 (git+https://github.com/mehcode/config-rs?rev=53e43fb)",
  "http",
  "httpmock 0.6.6",
  "parameterized",

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -5,8 +5,6 @@ http:
   listen: "127.0.0.1:8080"
   workers: null
 
-suggestion_providers: {}
-
 redis:
   url: redis://127.0.0.1:6379
 

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -29,3 +29,7 @@ public_documentation: null
 
 location:
   maxmind_database: null
+
+provider_settings:
+  type: local
+  path: ./config/providers/base.yaml

--- a/config/ci.yaml
+++ b/config/ci.yaml
@@ -19,3 +19,7 @@ logging:
 
 sentry:
   mode: "disabled"
+
+provider_settings:
+  type: local
+  path: ./config/providers/ci.yaml

--- a/config/ci.yaml
+++ b/config/ci.yaml
@@ -17,16 +17,5 @@ logging:
   # The minimum level that logs should be reported at
   levels: ["DEBUG"]
 
-# The suggestion providers to enable
-suggestion_providers:
-  test_wiki_fruit:
-    type: "wiki_fruit"
-  test_remote_settings:
-    type: memory_cache
-    inner:
-      type: remote_settings
-      collection: quicksuggest
-      suggestion_score: 0.3
-
 sentry:
   mode: "disabled"

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -3,15 +3,6 @@ debug: true
 logging:
   format: pretty
 
-suggestion_providers:
-  adm:
-    type: remote_settings
-    collection: "quicksuggest"
-  wiki_fruit:
-    type: wiki_fruit
-  debug:
-    type: debug
-
 location:
   maxmind_database: "./dev/GeoLite2-City-Test.mmdb"
 

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -8,3 +8,7 @@ location:
 
 sentry:
   mode: local_debug
+
+provider_settings:
+  type: local
+  path: ./config/providers/development.yaml

--- a/config/production.yaml
+++ b/config/production.yaml
@@ -8,3 +8,7 @@ logging:
 
 sentry:
   mode: release
+
+provider_settings:
+  type: local
+  path: ./config/providers/production.yaml

--- a/config/providers/base.yaml
+++ b/config/providers/base.yaml
@@ -1,0 +1,1 @@
+suggestion_providers: {}

--- a/config/providers/base.yaml
+++ b/config/providers/base.yaml
@@ -1,1 +1,1 @@
-suggestion_providers: {}
+--- # Suggestion providers

--- a/config/providers/ci.yaml
+++ b/config/providers/ci.yaml
@@ -1,6 +1,6 @@
 --- # Suggestion providers
 test_wiki_fruit:
-  type: "wiki_fruit"
+  type: wiki_fruit
 test_remote_settings:
   type: memory_cache
   inner:

--- a/config/providers/ci.yaml
+++ b/config/providers/ci.yaml
@@ -1,0 +1,9 @@
+suggestion_providers:
+  test_wiki_fruit:
+    type: "wiki_fruit"
+  test_remote_settings:
+    type: memory_cache
+    inner:
+      type: remote_settings
+      collection: quicksuggest
+      suggestion_score: 0.3

--- a/config/providers/ci.yaml
+++ b/config/providers/ci.yaml
@@ -1,9 +1,9 @@
-suggestion_providers:
-  test_wiki_fruit:
-    type: "wiki_fruit"
-  test_remote_settings:
-    type: memory_cache
-    inner:
-      type: remote_settings
-      collection: quicksuggest
-      suggestion_score: 0.3
+--- # Suggestion providers
+test_wiki_fruit:
+  type: "wiki_fruit"
+test_remote_settings:
+  type: memory_cache
+  inner:
+    type: remote_settings
+    collection: quicksuggest
+    suggestion_score: 0.3

--- a/config/providers/development.yaml
+++ b/config/providers/development.yaml
@@ -1,7 +1,7 @@
 --- # Suggestion providers
 adm:
   type: remote_settings
-  collection: "quicksuggest"
+  collection: quicksuggest
 wiki_fruit:
   type: wiki_fruit
 debug:

--- a/config/providers/development.yaml
+++ b/config/providers/development.yaml
@@ -1,0 +1,8 @@
+suggestion_providers:
+  adm:
+    type: remote_settings
+    collection: "quicksuggest"
+  wiki_fruit:
+    type: wiki_fruit
+  debug:
+    type: debug

--- a/config/providers/development.yaml
+++ b/config/providers/development.yaml
@@ -1,8 +1,8 @@
-suggestion_providers:
-  adm:
-    type: remote_settings
-    collection: "quicksuggest"
-  wiki_fruit:
-    type: wiki_fruit
-  debug:
-    type: debug
+--- # Suggestion providers
+adm:
+  type: remote_settings
+  collection: "quicksuggest"
+wiki_fruit:
+  type: wiki_fruit
+debug:
+  type: debug

--- a/config/providers/production.yaml
+++ b/config/providers/production.yaml
@@ -1,0 +1,1 @@
+suggestion_providers: {}

--- a/config/providers/production.yaml
+++ b/config/providers/production.yaml
@@ -1,1 +1,1 @@
-suggestion_providers: {}
+--- # Suggestion providers

--- a/config/providers/test.yaml
+++ b/config/providers/test.yaml
@@ -1,0 +1,1 @@
+suggestion_providers: {}

--- a/config/providers/test.yaml
+++ b/config/providers/test.yaml
@@ -1,1 +1,1 @@
-suggestion_providers: {}
+--- # Suggestion providers

--- a/config/test.yaml
+++ b/config/test.yaml
@@ -21,3 +21,7 @@ sentry:
 logging:
   levels:
     - DEBUG
+
+provider_settings:
+  type: local
+  path: ./config/providers/test.yaml

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -15,7 +15,7 @@ These are the settings sources, with later sources overriding earlier ones.
   provides the default values for most settings.
 
 - Per-environment configuration files in the `config` directory. The environment
-  is selected using the environment variable `MERINO_ENV`. The settings for that
+  is selected using the environment variable `MERINO__ENV`. The settings for that
   environment are then loaded from `config/${env}.yaml`, if it exists. The
   default environment is "development". A "production" environment is also
   provided.
@@ -24,26 +24,26 @@ These are the settings sources, with later sources overriding earlier ones.
   `config/local.yaml`. This file is in `.gitignore` and is safe to use for local
   configuration and secrets if desired.
 
-- Environment variables that begin with `MERINO_` and use `__` (a double
+- Environment variables that begin with `MERINO` and use `__` (a double
   underscore) as a level separator. For example, `Settings::http::workers` can
-  be controlled from the environment variable `MERINO_HTTP__WORKERS`.
+  be controlled from the environment variable `MERINO__HTTP__WORKERS`.
 
 The names given below are of the form "`yaml.path` (`ENVIRONMENT_VAR`)"
 
 ### General
 
-- `env` (`MERINO_ENV`) - Only settable from environment variables. Controls
+- `env` (`MERINO__ENV`) - Only settable from environment variables. Controls
   which environment configuration is loaded, as described above.
 
-- `debug` (`MERINO_DEBUG`) - Boolean that enables additional features to debug
+- `debug` (`MERINO__DEBUG`) - Boolean that enables additional features to debug
   the application. This should not be set to true in public environments, as it
   reveals all configuration, including any configured secrets.
 
-- `public_documentation` (`MERINO_PUBLIC_DOCUMENTATION`) - When users visit the
+- `public_documentation` (`MERINO__PUBLIC_DOCUMENTATION`) - When users visit the
   root of the server, they will be redirected to this URL. Preferable a public
   wiki page that explains what the server is and does.
 
-- `log_full_request` (`MERINO_LOG_FULL_REQUEST`) - Boolean that enables logging
+- `log_full_request` (`MERINO__LOG_FULL_REQUEST`) - Boolean that enables logging
   the entire suggestion request object as a part of the tracing log, including
   the search query. When the setting is false (default), the suggest request
   object should be logged, but the search query should be blank. Note that
@@ -53,9 +53,9 @@ The names given below are of the form "`yaml.path` (`ENVIRONMENT_VAR`)"
 
 Settings for the HTTP server.
 
-- `http.listen` (`MERINO_HTTP__LISTEN`) - An IP and port to listen on, such as
+- `http.listen` (`MERINO__HTTP__LISTEN`) - An IP and port to listen on, such as
   `127.0.0.1:8080` or `0.0.0.0:80`.
-- `http.workers` (`MERINO_HTTP__WORKERS`) - Optional. The number of worker
+- `http.workers` (`MERINO__HTTP__WORKERS`) - Optional. The number of worker
   threads that should be spawned to handle tasks. If not provided will default
   to the number of logical CPU cores available.
 
@@ -71,13 +71,13 @@ Settings to control the format and amount of logs generated.
   - `mozlog` (default in production) - A single line per event, formatted as
     JSON in [MozLog](https://wiki.mozilla.org/Firefox/Services/Logging) format.
 
-- `logging.info` (`MERINO_LOGGING__LEVELS`) - Minimum level of logs that should
+- `logging.info` (`MERINO__LOGGING__LEVELS`) - Minimum level of logs that should
   be reported. This should be a number of _entries_ separated by commas (for
   environment variables) or specified as list (YAML).
 
   This will be combined with the contents of the `RUST_LOG` environment variable
   for compatibility. `RUST_LOG` will take precedence over this setting. If the
-  environment variable `MERINO_LOGGING__LEVELS` is specified, all the settings
+  environment variable `MERINO__LOGGING__LEVELS` is specified, all the settings
   in the YAML file will be ignored.
 
   Each entry can be one of `ERROR`, `WARN`, `INFO`, `DEBUG`, or `TRACE` (in
@@ -90,13 +90,13 @@ Settings to control the format and amount of logs generated.
 
 Settings for Statsd/Datadog style metrics reporting.
 
-- `metrics.sink_host` (`MERINO_METRICS__SINK_ADDRESS`) - The IP or hostname to
+- `metrics.sink_host` (`MERINO__METRICS__SINK_ADDRESS`) - The IP or hostname to
   send metrics to over UDP. Defaults to `0.0.0.0`.
 
-- `metrics.sink_port` (`MERINO_METRICS__SINK_PORT`) - The port to send metrics
+- `metrics.sink_port` (`MERINO__METRICS__SINK_PORT`) - The port to send metrics
   to over UDP. Defaults to 8125.
 
-- `max_queue_size_kb` (`MERINO_METRICS__MAX_QUEUE_SIZE_KB`) - The maximum size
+- `max_queue_size_kb` (`MERINO__METRICS__MAX_QUEUE_SIZE_KB`) - The maximum size
   of the buffer that holds events waiting to be sent. If unsent events rise
   above this, then metrics will be lost. Defaults to 32KB.
 
@@ -104,7 +104,7 @@ Settings for Statsd/Datadog style metrics reporting.
 
 Error reporting via Sentry.
 
-- `sentry.mode` (`MERINO_SENTRY__MODE`) - The type of Sentry integration to
+- `sentry.mode` (`MERINO__SENTRY__MODE`) - The type of Sentry integration to
   enable. One of `release`, `server_debug`, `local_debug`, or `disabled`. The
   two `debug` settings should only be used for local development.
 
@@ -135,7 +135,7 @@ See that page for DSN information. The following two settings are required:
 
 Connection to Redis. This is used by the Redis provider cache below.
 
-- `redis.url` (`MERINO_REDIS__URL`) - The URL to connect Redis at. Example:
+- `redis.url` (`MERINO__REDIS__URL`) - The URL to connect Redis at. Example:
   `redis://127.0.0.1/0`.
 
 ### Remote_settings
@@ -143,15 +143,15 @@ Connection to Redis. This is used by the Redis provider cache below.
 Connection to Remote Settings. This is used by the Remote Settings suggestion
 provider below.
 
-- `remote_settings.server` (`MERINO_REMOTE_SETTINGS__SERVER`) - The server to
+- `remote_settings.server` (`MERINO__REMOTE_SETTINGS__SERVER`) - The server to
   sync from. Example: `https://firefox.settings.services.mozilla.com`.
 
-- `remote_settings.default_bucket` (`MERINO_REMOTE_SETTINGS__DEFAULT_BUCKET`) -
+- `remote_settings.default_bucket` (`MERINO__REMOTE_SETTINGS__DEFAULT_BUCKET`) -
   The bucket to use for Remote Settings providers if not specified in the
   provider config. Example: "main".
 
 - `remote_settings.default_collection`
-  (`MERINO_REMOTE_SETTINGS__DEFAULT_COLLECTION`) - The collection to use for
+  (`MERINO__REMOTE_SETTINGS__DEFAULT_COLLECTION`) - The collection to use for
   Remote Settings providers if not specified in the provider config. Example:
   "quicksuggest".
 
@@ -159,7 +159,7 @@ provider below.
 
 Configuration for determining the location of users.
 
-- `location.maxmind_database` (`MERINO_LOCATION__MAXMIND_DATABASE`) - Path to a
+- `location.maxmind_database` (`MERINO__LOCATION__MAXMIND_DATABASE`) - Path to a
   MaxMind GeoIP database file. Optional. If not specified, geolocation will be
   disabled.
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -5,7 +5,9 @@
 Merino's settings can be specified in two ways: a YAML file placed in a specific
 location, or via environment variables. Not all settings can be set with
 environment variables, however. Notably, provider configuration must be done
-with YAML.
+with its own YAML file.
+
+### [File organization](#file-organization)
 
 These are the settings sources, with later sources overriding earlier ones.
 
@@ -163,8 +165,14 @@ Configuration for determining the location of users.
 
 ### Provider Configuration
 
-The configuration for suggestion providers. These settings cannot be configured
-via environment variable.
+The configuration for suggestion providers.
+
+Note that the provider settings are configured by separate YAML files located in
+`config/providers`. These settings cannot be configured via environment variables.
+The file organization is identical to the [top level settings](#file-organization)
+with the same source overriding rule.
+
+Each configuration file follows the structure:
 
 - `suggestion_providers` - Providers to use to generate suggestions. This should
   be a map where the keys are provider IDs will be used in the API to enable and

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -167,10 +167,34 @@ Configuration for determining the location of users.
 
 The configuration for suggestion providers.
 
-Note that the provider settings are configured by separate YAML files located in
-`config/providers`. These settings cannot be configured via environment variables.
-The file organization is identical to the [top level settings](#file-organization)
-with the same source overriding rule.
+Note that the provider settings are configured either by a separate YAML file
+located in `config/providers` or by a remote source backed by an HTTP endpoint.
+You can use `provider_settings` to configure how & where Merino to load the
+settings.
+
+#### `Provider Settings`
+
+You can specify the "type" and the "location" of the provider settings. The
+"type" could be `local` or `remote`. For `local` sources, use `path` to specify
+the location; Use `uri` for `remote` sources. Note that only YAML is supported
+for remote sources, whereas all the common formats (JSON, YAML, TOML, etc) are
+supported for local sources.
+
+_Examples_:
+
+- A local source
+```yaml
+provider_settings:
+  type: local
+  path: ./config/providers/base.yaml
+```
+
+- A remote source
+```yaml
+provider_settings:
+  type: remote
+  uri: https://example.org/settings
+```
 
 #### Configuration Object
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -176,7 +176,7 @@ settings.
 
 You can specify the "type" and the "location" of the provider settings. The
 "type" could be `local` or `remote`. For `local` sources, use `path` to specify
-the location; Use `uri` for `remote` sources. Note that only YAML is supported
+the location; Use `uri` for `remote` sources. Note that only JSON is supported
 for remote sources, whereas all the common formats (JSON, YAML, TOML, etc) are
 supported for local sources.
 

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -172,16 +172,39 @@ Note that the provider settings are configured by separate YAML files located in
 The file organization is identical to the [top level settings](#file-organization)
 with the same source overriding rule.
 
-Each configuration file follows the structure:
-
-- `suggestion_providers` - Providers to use to generate suggestions. This should
-  be a map where the keys are provider IDs will be used in the API to enable and
-  disable providers per request. The values are provider configuration objects,
-  detailed below. Some providers can take other providers as children. Because
-  of this, each key in this config is referred to as a "provider tree".
+#### Configuration Object
 
 Each provider configuration has a `type`, listed below, and it's own individual
 settings.
+
+_Example_:
+
+```yaml
+wiki_fruit:
+  type: wiki_fruit
+```
+
+#### Configuration File
+
+Each configuration file should be a map where the keys are provider IDs will be
+used in the API to enable and disable providers per request. The values are
+provider configuration objects, detailed below. Some providers can takes other
+providers as children. Because of this, each key in this config is referred to
+as a "provider tree".
+
+_Example_:
+
+```yaml
+adm:
+  type: memory_cache
+  inner:
+    type: remote_settings
+    collection: "quicksuggest"
+wiki_fruit:
+  type: wiki_fruit
+debug:
+  type: debug
+```
 
 #### Leaf Providers
 
@@ -210,15 +233,14 @@ These are providers that extend, combine, or otherwise modify other providers.
   _Example_:
 
   ```yaml
-  suggestion_providers:
-    sample_multi:
-      type: multiplexer
-      providers:
-        - fixed:
-          type: fixed
-          value: I'm a banana
-        - debug:
-          type: debug
+  sample_multi:
+    type: multiplexer
+    providers:
+      - fixed:
+        type: fixed
+        value: I'm a banana
+      - debug:
+        type: debug
   ```
 
 - Timeout - Returns an empty response if the wrapped provider takes too long to
@@ -241,19 +263,18 @@ These are providers that extend, combine, or otherwise modify other providers.
   _Example_:
 
   ```yaml
-  suggestion_providers:
-    filtered:
-      type: keyword_filter
-      suggestion_blocklist:
-        no_banana: "(Banana|banana|plant)"
-      inner:
-        type: multiplexer
-        providers:
-          - fixed:
-            type: fixed
-            value: I'm a banana
-          - debug:
-            type: debug
+  filtered:
+    type: keyword_filter
+    suggestion_blocklist:
+      no_banana: "(Banana|banana|plant)"
+    inner:
+      type: multiplexer
+      providers:
+        - fixed:
+          type: fixed
+          value: I'm a banana
+        - debug:
+          type: debug
   ```
 
 - Stealth - Runs another provider, but hides the results. Useful for load

--- a/merino-settings/Cargo.toml
+++ b/merino-settings/Cargo.toml
@@ -5,9 +5,11 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-config = "0.11.0"
+async-trait = "0.1"
+config = { git = "https://github.com/mehcode/config-rs", branch = "master" }
 http = "0.2"
 redis = "^0.20"
+reqwest = "0.11"
 # Pin to 0.19 until our on premise server updates to >= 20.6.
 sentry = "0.19"
 serde = { version = "1.0.125", features = ["derive"] }
@@ -17,5 +19,7 @@ tracing = "0.1.29"
 tracing-subscriber = { version = "0.2.18", features = ["env-filter"] }
 
 [dev_dependencies]
+httpmock = "0.6"
 parameterized = "0.3"
 serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/merino-settings/Cargo.toml
+++ b/merino-settings/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-config = { git = "https://github.com/mehcode/config-rs", branch = "master" }
+config = { git = "https://github.com/mehcode/config-rs", rev = "53e43fb" }
 http = "0.2"
 redis = "^0.20"
 reqwest = "0.11"

--- a/merino-settings/src/lib.rs
+++ b/merino-settings/src/lib.rs
@@ -8,16 +8,16 @@
 //! 1. A base configuration checked into the repository, in `config/base.yaml`.
 //!    This provides the default values for most settings.
 //! 2. Per-environment configuration files in the `config` directory. The
-//!    environment is selected using the environment variable `MERINO_ENV`. The
+//!    environment is selected using the environment variable `MERINO__ENV`. The
 //!    settings for that environment are then loaded from `config/${env}.yaml`, if
 //!    it exists. The default environment is "development". A "production"
 //!    environment is also provided.
 //! 3. A local configuration file not checked into the repository, at
 //!    `config/local.yaml`. This file is in `.gitignore` and is safe to use for
 //!    local configuration and secrets if desired.
-//! 4. Environment variables that begin with `MERINO_` and use `__` as a level
+//! 4. Environment variables that begin with `MERINO` and use `__` as a level
 //!    separator. For example, `Settings::http::workers` can be controlled from the
-//!    environment variable `MERINO_HTTP__WORKERS`.
+//!    environment variable `MERINO__HTTP__WORKERS`.
 //!
 //! Tests should use `Settings::load_for_test` which only reads from
 //! `config/base.yaml`, `config/test.yaml`, and `config/local_test.yaml` (if it
@@ -49,7 +49,7 @@ use crate::providers::{SuggestionProviderConfig, SuggestionProviderSettings};
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Settings {
     /// The environment Merino is running in. Should only be set with the
-    /// `MERINO_ENV` environment variable.
+    /// `MERINO__ENV` environment variable.
     pub env: String,
 
     /// Enable additional features to debug the application. This should not be
@@ -299,7 +299,7 @@ impl Settings {
     /// If any of the configured values are invalid, or if any of the required
     /// configuration files are missing.
     pub async fn load() -> Result<Self> {
-        let merino_env = std::env::var("MERINO_ENV").unwrap_or_else(|_| "development".to_string());
+        let merino_env = std::env::var("MERINO__ENV").unwrap_or_else(|_| "development".to_string());
 
         let s = Config::builder()
             // Start off with the base config.
@@ -308,10 +308,10 @@ impl Settings {
             .add_source(File::with_name(&format!("config/{}", merino_env)).required(false))
             // Add a local configuration file that is `.gitignore`ed.
             .add_source(File::with_name("config/local").required(false))
-            // Add environment variables that start with "MERINO_" and have "__" to
-            // separate levels. For example, `MERINO_HTTP__LISTEN` maps to
+            // Add environment variables that start with "MERINO" and have "__" to
+            // separate levels. For example, `MERINO__HTTP__LISTEN` maps to
             // `Settings::http::listen`.
-            .add_source(Environment::default().prefix("MERINO").separator("__"))
+            .add_source(Environment::with_prefix("MERINO").separator("__"))
             .set_override("env", merino_env.as_str())
             .context("loading merino environment name")?
             .build()

--- a/merino-settings/src/lib.rs
+++ b/merino-settings/src/lib.rs
@@ -334,7 +334,7 @@ impl Settings {
             .add_source(File::with_name("../config/base"))
             // Merge in test specific config.
             .add_source(File::with_name("../config/test"))
-            // Add a local  in test specific config.
+            // Add a local in test specific config.
             .add_source(File::with_name("../config/local_test").required(false))
             // Add a local configuration file that is `.gitignore`ed.
             .set_override("env", "test")

--- a/merino-settings/src/lib.rs
+++ b/merino-settings/src/lib.rs
@@ -307,7 +307,7 @@ impl Settings {
         let mut settings: Settings =
             serde_path_to_error::deserialize(s).context("Deserializing settings")?;
         let provider_settings = SuggestionProviderSettings::load()?;
-        settings.suggestion_providers = provider_settings.suggestion_providers;
+        settings.suggestion_providers = provider_settings.0;
 
         Ok(settings)
     }
@@ -331,7 +331,7 @@ impl Settings {
 
         let mut settings: Settings = s.try_into().expect("Could not convert settings");
         let provider_settings = SuggestionProviderSettings::load_for_tests();
-        settings.suggestion_providers = provider_settings.suggestion_providers;
+        settings.suggestion_providers = provider_settings.0;
 
         settings
     }

--- a/merino-settings/src/logging.rs
+++ b/merino-settings/src/logging.rs
@@ -16,7 +16,7 @@ pub struct LoggingSettings {
     /// `RUST_LOG`, with values from the environment variable overriding the
     /// config file.
     ///
-    /// The environment variable `MERINO_LOGGING__LEVELS` can be used. This
+    /// The environment variable `MERINO__LOGGING__LEVELS` can be used. This
     /// environment variable will completely override the config file, and wil be
     /// merged with the envvar `RUST_LOG`. `RUST_LOG` takes precedence again.
     ///

--- a/merino-settings/src/providers.rs
+++ b/merino-settings/src/providers.rs
@@ -1,5 +1,10 @@
+use crate::ProviderSettings;
 use anyhow::{Context, Result};
-use config::{Config, File};
+use async_trait::async_trait;
+use config::{
+    builder::AsyncState, AsyncSource, Config, ConfigBuilder, ConfigError, File, FileFormat, Format,
+    Value,
+};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DurationMilliSeconds, DurationSeconds};
 use std::collections::HashMap;
@@ -226,7 +231,9 @@ impl SuggestionProviderSettings {
     /// Load settings for suggestions providers.
     ///
     /// The organization of the provider configuration files is identical to the
-    /// top level settings.
+    /// top level settings except that it only uses one source (local or remote)
+    /// for each run-mode, and that is configured by `provider_settings` of the
+    /// top-level settings.
     ///
     /// Note that settings for suggestion providers cannot be configured via
     /// environment variables.
@@ -234,55 +241,84 @@ impl SuggestionProviderSettings {
     /// # Errors
     /// If any of the configured values are invalid, or if any of the required
     /// configuration files are missing.
-    pub fn load() -> Result<Self> {
-        let mut s = Config::new();
-
-        // Start off with the base config.
-        s.merge(File::with_name("./config/providers/base"))
-            .context("loading base config for suggestion providers")?;
-
-        // Merge in an environment specific config.
-        let merino_env = std::env::var("MERINO_ENV").unwrap_or_else(|_| "development".to_string());
-        s.merge(File::with_name(&format!("./config/providers/{}", merino_env)).required(false))
-            .context("loading environment config for suggestion providers")?;
-
-        // Add a local configuration file that is `.gitignore`ed.
-        s.merge(File::with_name("./config/providers/local").required(false))
-            .context("loading local config for suggestion providers")?;
+    pub async fn load(settings: &ProviderSettings) -> Result<Self> {
+        let builder = ConfigBuilder::<AsyncState>::default();
+        let s = match settings {
+            ProviderSettings::Local { path, .. } => builder.add_source(File::with_name(path)),
+            ProviderSettings::Remote { uri, .. } => {
+                // TODO(nanj): drop the hardcoded YAML to support other formats.
+                builder.add_async_source(ProviderHttpSource::new(uri.to_owned(), FileFormat::Yaml))
+            }
+        }
+        .build()
+        .await
+        .context("loading settings for suggestion providers")?;
 
         serde_path_to_error::deserialize(s)
             .context("Deserializing settings for suggestion providers")
     }
 
     /// Load settings for suggestion providers from configuration files for tests.
+    ///
+    /// Unlike [`Self::load()`], this function is synchronous to facilitate testing.
     pub fn load_for_tests() -> Self {
-        let mut s = Config::new();
+        let s = Config::builder()
+            // Start off with the base config.
+            .add_source(File::with_name("../config/providers/test"))
+            // Merge in test specific config.
+            .add_source(File::with_name("../config/providers/local_test").required(false))
+            .build()
+            .expect("Could not load settings for tests");
 
-        s.merge(File::with_name("../config/providers/test"))
-            .expect("Could not load test settings for suggestion providers");
+        s.try_deserialize().expect("Could not convert settings")
+    }
+}
 
-        // Add a local configuration file that is `.gitignore`ed.
-        s.merge(File::with_name("../config/providers/local_test").required(false))
-            .expect("Could not load local test settings for suggestion providers");
+/// Async HTTP source for suggestion providers
+#[derive(Debug)]
+struct ProviderHttpSource {
+    /// URI to the settings source
+    uri: String,
 
-        s.try_into()
-            .expect("Could not convert settings for suggestion providers")
+    /// File format such as YAML, JSON, TOML, etc
+    format: FileFormat,
+}
+
+impl ProviderHttpSource {
+    pub fn new(uri: String, format: FileFormat) -> Self {
+        Self { uri, format }
+    }
+}
+
+#[async_trait]
+impl AsyncSource for ProviderHttpSource {
+    async fn collect(&self) -> Result<HashMap<String, Value>, ConfigError> {
+        reqwest::get(&self.uri)
+            .await
+            .map_err(|e| ConfigError::Foreign(Box::new(e)))?
+            .text()
+            .await
+            .map_err(|e| ConfigError::Foreign(Box::new(e)))
+            .and_then(|text| {
+                self.format
+                    .parse(Some(&self.uri), &text)
+                    .map_err(|e| ConfigError::Foreign(e))
+            })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{providers::SuggestionProviderConfig, Settings};
+    use crate::{providers::SuggestionProviderConfig, ProviderSettings, Settings};
     use anyhow::{Context, Result};
     use config::{Config, File, Value};
+    use httpmock::prelude::*;
     use serde_json::json;
+
+    use super::SuggestionProviderSettings;
 
     #[test]
     fn provider_defaults_are_optional() -> Result<()> {
-        let mut config = Config::new();
-        config.merge(File::with_name("../config/base"))?;
-        config.set("env", "test")?;
-
         // Providers are allowed to have required fields, if there is no logical
         // default. If that's the case, make sure to add them here. Don't
         // provide any values for fields that are options.
@@ -301,10 +337,16 @@ mod tests {
         });
 
         let value_config: Value = serde_json::from_value(value_json.clone())?;
-        config.set("suggestion_providers", value_config)?;
+        let config = Config::builder()
+            .add_source(File::with_name("../config/base"))
+            .set_override("env", "test")
+            .context("Could not set env")?
+            .set_override("suggestion_providers", value_config)
+            .context("Could not set suggestion providers")?
+            .build()?;
 
         let settings = config
-            .try_into::<Settings>()
+            .try_deserialize::<Settings>()
             .context("could not convert settings")?;
 
         let mut found_providers = 0;
@@ -336,5 +378,75 @@ mod tests {
         assert_eq!(found_providers, 11);
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn provider_remote_source() {
+        let server = MockServer::start();
+
+        let remote_endpoint = server.mock(|when, then| {
+            when.method(GET).path("/yaml_source");
+            then.status(200)
+                .header("content-type", "application/x-yaml")
+                .body(
+                    r#"
+                        adm:
+                          type: remote_settings
+                          collection: quicksuggest
+                        wiki_fruit:
+                          type: wiki_fruit
+                        debug:
+                          type: debug
+                    "#,
+                );
+        });
+
+        let settings = ProviderSettings::Remote {
+            uri: server.url("/yaml_source"),
+        };
+
+        let providers = SuggestionProviderSettings::load(&settings)
+            .await
+            .unwrap();
+
+        remote_endpoint.assert();
+        assert_eq!(providers.0.len(), 3);
+        assert!(matches!(
+            providers.0.get("adm").unwrap(),
+            SuggestionProviderConfig::RemoteSettings(_)
+        ));
+        assert!(matches!(
+            providers.0.get("wiki_fruit").unwrap(),
+            SuggestionProviderConfig::WikiFruit
+        ));
+        assert!(matches!(
+            providers.0.get("debug").unwrap(),
+            SuggestionProviderConfig::Debug
+        ));
+    }
+
+    #[tokio::test]
+    async fn provider_local_source() {
+        let settings = ProviderSettings::Local {
+            path: "../config/providers/development.yaml".to_owned(),
+        };
+
+        let providers = SuggestionProviderSettings::load(&settings)
+            .await
+            .unwrap();
+
+        assert_eq!(providers.0.len(), 3);
+        assert!(matches!(
+            providers.0.get("adm").unwrap(),
+            SuggestionProviderConfig::RemoteSettings(_)
+        ));
+        assert!(matches!(
+            providers.0.get("wiki_fruit").unwrap(),
+            SuggestionProviderConfig::WikiFruit
+        ));
+        assert!(matches!(
+            providers.0.get("debug").unwrap(),
+            SuggestionProviderConfig::Debug
+        ));
     }
 }

--- a/merino-settings/src/providers.rs
+++ b/merino-settings/src/providers.rs
@@ -218,7 +218,7 @@ impl Default for StealthConfig {
 }
 
 /// Settings for Merino suggestion providers.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct SuggestionProviderSettings(pub HashMap<String, SuggestionProviderConfig>);
 

--- a/merino-settings/src/providers.rs
+++ b/merino-settings/src/providers.rs
@@ -233,7 +233,8 @@ impl SuggestionProviderSettings {
     /// The organization of the provider configuration files is identical to the
     /// top level settings except that it only uses one source (local or remote)
     /// for each run-mode, and that is configured by `provider_settings` of the
-    /// top-level settings.
+    /// top-level settings. Alternatively, remote configuration (via JSON) is
+    /// also supported.
     ///
     /// Note that settings for suggestion providers cannot be configured via
     /// environment variables.
@@ -246,8 +247,7 @@ impl SuggestionProviderSettings {
         let s = match settings {
             ProviderSettings::Local { path, .. } => builder.add_source(File::with_name(path)),
             ProviderSettings::Remote { uri, .. } => {
-                // TODO(nanj): drop the hardcoded YAML to support other formats.
-                builder.add_async_source(ProviderHttpSource::new(uri.to_owned(), FileFormat::Yaml))
+                builder.add_async_source(ProviderHttpSource::new(uri.to_owned(), FileFormat::Json))
             }
         }
         .build()
@@ -390,13 +390,18 @@ mod tests {
                 .header("content-type", "application/x-yaml")
                 .body(
                     r#"
-                        adm:
-                          type: remote_settings
-                          collection: quicksuggest
-                        wiki_fruit:
-                          type: wiki_fruit
-                        debug:
-                          type: debug
+                    {
+                        "adm": {
+                          "type": "remote_settings",
+                          "collection": "quicksuggest"
+                        },
+                        "wiki_fruit": {
+                          "type": "wiki_fruit"
+                        },
+                        "debug": {
+                          "type": "debug"
+                        }
+                    }
                     "#,
                 );
         });

--- a/merino-settings/src/providers.rs
+++ b/merino-settings/src/providers.rs
@@ -219,6 +219,7 @@ impl Default for StealthConfig {
 
 /// Settings for Merino suggestion providers.
 #[derive(Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct SuggestionProviderSettings(pub HashMap<String, SuggestionProviderConfig>);
 
 impl SuggestionProviderSettings {
@@ -250,7 +251,6 @@ impl SuggestionProviderSettings {
             .context("loading local config for suggestion providers")?;
 
         serde_path_to_error::deserialize(s)
-            .map(SuggestionProviderSettings)
             .context("Deserializing settings for suggestion providers")
     }
 
@@ -266,7 +266,6 @@ impl SuggestionProviderSettings {
             .expect("Could not load local test settings for suggestion providers");
 
         s.try_into()
-            .map(SuggestionProviderSettings)
             .expect("Could not convert settings for suggestion providers")
     }
 }

--- a/merino-settings/src/providers.rs
+++ b/merino-settings/src/providers.rs
@@ -387,7 +387,7 @@ mod tests {
         let remote_endpoint = server.mock(|when, then| {
             when.method(GET).path("/yaml_source");
             then.status(200)
-                .header("content-type", "application/x-yaml")
+                .header("content-type", "application/json")
                 .body(
                     r#"
                     {

--- a/merino-settings/src/providers.rs
+++ b/merino-settings/src/providers.rs
@@ -219,9 +219,7 @@ impl Default for StealthConfig {
 
 /// Settings for Merino suggestion providers.
 #[derive(Serialize, Deserialize)]
-pub struct SuggestionProviderSettings {
-    pub suggestion_providers: HashMap<String, SuggestionProviderConfig>,
-}
+pub struct SuggestionProviderSettings(pub HashMap<String, SuggestionProviderConfig>);
 
 impl SuggestionProviderSettings {
     /// Load settings for suggestions providers.
@@ -252,6 +250,7 @@ impl SuggestionProviderSettings {
             .context("loading local config for suggestion providers")?;
 
         serde_path_to_error::deserialize(s)
+            .map(SuggestionProviderSettings)
             .context("Deserializing settings for suggestion providers")
     }
 
@@ -267,6 +266,7 @@ impl SuggestionProviderSettings {
             .expect("Could not load local test settings for suggestion providers");
 
         s.try_into()
+            .map(SuggestionProviderSettings)
             .expect("Could not convert settings for suggestion providers")
     }
 }

--- a/merino-settings/src/providers.rs
+++ b/merino-settings/src/providers.rs
@@ -405,9 +405,7 @@ mod tests {
             uri: server.url("/yaml_source"),
         };
 
-        let providers = SuggestionProviderSettings::load(&settings)
-            .await
-            .unwrap();
+        let providers = SuggestionProviderSettings::load(&settings).await.unwrap();
 
         remote_endpoint.assert();
         assert_eq!(providers.0.len(), 3);
@@ -431,9 +429,7 @@ mod tests {
             path: "../config/providers/development.yaml".to_owned(),
         };
 
-        let providers = SuggestionProviderSettings::load(&settings)
-            .await
-            .unwrap();
+        let providers = SuggestionProviderSettings::load(&settings).await.unwrap();
 
         assert_eq!(providers.0.len(), 3);
         assert!(matches!(

--- a/merino-web/src/lib.rs
+++ b/merino-web/src/lib.rs
@@ -54,7 +54,7 @@ use crate::providers::SuggestionProviderRef;
 /// # tokio_test::block_on(async {
 /// let listener = std::net::TcpListener::bind("127.0.0.1:8080")
 ///     .expect("Failed to bind port");
-/// let settings = merino_settings::Settings::load()
+/// let settings = merino_settings::Settings::load().await
 ///     .expect("Failed to load settings");
 /// let metrics_client = cadence::StatsdClient::from_sink("merino", cadence::NopMetricSink);
 /// let providers = merino_web::providers::SuggestionProviderRef::init(&settings, &metrics_client)
@@ -77,7 +77,7 @@ use crate::providers::SuggestionProviderRef;
 ///
 /// let listener = TcpListener::bind("127.0.0.1:8080")
 ///     .expect("Failed to bind port");
-/// let settings = merino_settings::Settings::load()
+/// let settings = merino_settings::Settings::load().await
 ///     .expect("Failed to load settings");
 /// let metrics_client = cadence::StatsdClient::from_sink("merino", cadence::NopMetricSink);
 /// let providers = merino_web::providers::SuggestionProviderRef::init(&settings, &metrics_client)

--- a/merino/src/main.rs
+++ b/merino/src/main.rs
@@ -17,7 +17,9 @@ use tracing_subscriber::{layer::SubscriberExt, EnvFilter};
 /// Primary entry point
 #[actix_rt::main]
 async fn main() -> Result<()> {
-    let settings = merino_settings::Settings::load().context("Loading settings")?;
+    let settings = merino_settings::Settings::load()
+        .await
+        .context("Loading settings")?;
     let _sentry_guard = crate::sentry::init_sentry(&settings).context("initializing sentry")?;
     init_logging(&settings).context("initializing logging")?;
     let metrics_client = init_metrics(&settings).context("initializing metrics")?;

--- a/test-engineering/contract-tests/docker-compose.yml
+++ b/test-engineering/contract-tests/docker-compose.yml
@@ -7,10 +7,10 @@ services:
     container_name: merino
     environment:
       # The configuration preset to use
-      MERINO_ENV: "ci"
-      MERINO_REMOTE_SETTINGS__DEFAULT_BUCKET: main
-      MERINO_REMOTE_SETTINGS__DEFAULT_COLLECTION: quicksuggest
-      MERINO_REMOTE_SETTINGS__SERVER: http://kinto:8888
+      MERINO__ENV: "ci"
+      MERINO__REMOTE_SETTINGS__DEFAULT_BUCKET: main
+      MERINO__REMOTE_SETTINGS__DEFAULT_COLLECTION: quicksuggest
+      MERINO__REMOTE_SETTINGS__SERVER: http://kinto:8888
     depends_on:
       - kinto
       - kinto-attachments

--- a/test-engineering/load-tests/docker-compose.yml
+++ b/test-engineering/load-tests/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build: ../..
     environment:
       # TODO: This needs to be updated or kinto needs to be added
-      MERINO_ENV: "ci"
+      MERINO__ENV: "ci"
     volumes:
       - ../../dev:/tmp/dev
 


### PR DESCRIPTION
This fixes #293 

Change highlights:
* Moved the configurations for suggestion provider to its own settings
* Added a new helper struct `SuggestionProviderSettings` to load settings. My understanding is that we can build up the dynamic loading around it later.   

Notes:
* This requires a change to `cloudops-infra`       
* The configuration sources for providers and the overriding rules are identical to the top-level settings. I am open to further simplifying that if necessary
* The top-level `Settings` still hold the `suggestion_providers` as I don't see much benefit of spitting it from the `Settings` for now.
