### PR TITLE
SVCSE-241 Add "sensitive" flag to web.suggest.request log messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3785,9 +3785,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]

--- a/docs/data.md
+++ b/docs/data.md
@@ -9,6 +9,10 @@ This list does not include any `DEBUG` or `TRACE` level events, since those are
 not logged by default in production. The events below are grouped by crate, and
 the level and type of the log is listed.
 
+Any log containing sensitive data must include a boolean field `sensitive`
+that is set to `true` to exempt it from flowing to the generally accessible
+log inspection interfaces.
+
 ### `merino-adm`
 
 - `INFO adm.remote-settings.sync-start` - The Remote Settings provider has
@@ -27,6 +31,7 @@ the level and type of the log is listed.
 - `INFO web.suggest.request` - A suggestion request is being processed. This
   event will include fields for all relevant details of the request. **Fields:**
 
+  - `sensitive` - Always set to true to ensure proper routing.
   - `query` - If query logging is enabled, the text the user typed. Otherwise an
     empty string.
   - `country` - The country the request came from.

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -15,8 +15,8 @@ These are the settings sources, with later sources overriding earlier ones.
   provides the default values for most settings.
 
 - Per-environment configuration files in the `config` directory. The environment
-  is selected using the environment variable `MERINO__ENV`. The settings for that
-  environment are then loaded from `config/${env}.yaml`, if it exists. The
+  is selected using the environment variable `MERINO__ENV`. The settings for
+  that environment are then loaded from `config/${env}.yaml`, if it exists. The
   default environment is "development". A "production" environment is also
   provided.
 
@@ -183,6 +183,7 @@ supported for local sources.
 _Examples_:
 
 - A local source
+
 ```yaml
 provider_settings:
   type: local
@@ -190,6 +191,7 @@ provider_settings:
 ```
 
 - A remote source
+
 ```yaml
 provider_settings:
   type: remote
@@ -353,5 +355,12 @@ testing.
 
 - Null - A provider that never suggests anything. Useful to fill in combinators
   and caches for testing.
+
   - `type="null"` - Note that `null` in YAML is an actual null value, so this
     must be specified as the string `"null"`.
+
+- Fixed - A suggestion provider that provides a fixed response with a
+  customizable title.
+
+  - `value` - A string that will be used for the title of the fixed suggestion.
+    Required.

--- a/merino-integration-tests/src/suggest.rs
+++ b/merino-integration-tests/src/suggest.rs
@@ -401,7 +401,8 @@ async fn suggest_logs_searches_when_requested(
             continue;
         }
         // If the type is correct, the `has` assertion above ensures everything is ok
-        if event.fields.get("r#type") == Some(&Value::String("web.suggest.request".to_string())) {
+        if event.fields.get("r#type") == Some(&json!("web.suggest.request")) {
+            assert_eq!(event.fields.get("sensitive"), Some(&json!(true)));
             continue;
         }
         // If this is a non-request, non-debug/trace log, then it should not have the query anywhere in it

--- a/merino-web/src/endpoints/suggest.rs
+++ b/merino-web/src/endpoints/suggest.rs
@@ -190,6 +190,7 @@ fn safe_log_request(
 
     tracing::info!(
         r#type = "web.suggest.request",
+        sensitive = true,
         accepts_english = ?request.accepts_english,
         city = request.city.as_deref(),
         country = request.country.as_deref(),


### PR DESCRIPTION
See https://mozilla-hub.atlassian.net/browse/SVCSE-241

The design for this particular field was proposed and accepted in the
[Add "sensitive" field for log routing](https://docs.google.com/document/d/1WI5XotvZoUNaw3sQQfQtn8C7RBv1wKmFiYpvd7yobh8/edit#)
decision doc.