### PR TITLE
feat(wikipedia): Add basic data model to index Wikipedia into Elasticsearch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "ahash 0.7.4",
- "base64",
+ "base64 0.13.0",
  "bitflags",
  "bytes 1.0.1",
  "bytestring",
@@ -263,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.42"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
 name = "arc-swap"
@@ -319,6 +319,19 @@ dependencies = [
  "concurrent-queue",
  "event-listener",
  "futures-core",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "795814bc6dce6c2e6af7e6aa5a96d99543c88808596300dbfb56372b4456f689"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite 0.2.7",
+ "tokio 1.15.0",
 ]
 
 [[package]]
@@ -528,6 +541,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "base64"
@@ -825,6 +844,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2209c310e29876f7f0b2721e7e26b84aff178aa3da5d091f9bfbf47669e60e3"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1192,10 +1220,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "elasticsearch"
+version = "7.14.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d853e1c104dbad916425c88e72ac5b73db65bbc22d3b8ab945174e68df91e6f0"
+dependencies = [
+ "base64 0.11.0",
+ "bytes 1.0.1",
+ "dyn-clone",
+ "lazy_static",
+ "percent-encoding",
+ "reqwest 0.11.4",
+ "rustc_version 0.2.3",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "url",
+ "void",
+]
 
 [[package]]
 name = "ena"
@@ -1305,6 +1359,18 @@ name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
+name = "flate2"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1671,7 +1737,7 @@ dependencies = [
  "assert-json-diff",
  "async-object-pool",
  "async-trait",
- "base64",
+ "base64 0.13.0",
  "basic-cookies",
  "crossbeam-utils",
  "difference",
@@ -1698,7 +1764,7 @@ dependencies = [
  "assert-json-diff",
  "async-object-pool",
  "async-trait",
- "base64",
+ "base64 0.13.0",
  "basic-cookies",
  "crossbeam-utils",
  "form_urlencoded",
@@ -2315,6 +2381,19 @@ dependencies = [
  "tracing-futures",
  "uuid",
  "woothee",
+]
+
+[[package]]
+name = "merino-wikipedia"
+version = "0.5.1"
+dependencies = [
+ "anyhow",
+ "elasticsearch",
+ "merino-settings",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tokio 1.15.0",
 ]
 
 [[package]]
@@ -3091,7 +3170,7 @@ source = "git+https://github.com/mozilla-services/remote-settings-client?tag=v1.
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.13.0",
  "canonical_json",
  "derive_builder",
  "hex",
@@ -3120,7 +3199,7 @@ version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0718f81a8e14c4dbb3b34cf23dc6aaf9ab8a0dfec160c534b3dbca1aaa21f47c"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "bytes 0.5.6",
  "encoding_rs",
  "futures-core",
@@ -3156,7 +3235,8 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
 dependencies = [
- "base64",
+ "async-compression",
+ "base64 0.13.0",
  "bytes 1.0.1",
  "encoding_rs",
  "futures-core",
@@ -3179,6 +3259,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio 1.15.0",
  "tokio-native-tls",
+ "tokio-util 0.6.7",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3207,7 +3288,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b861ecaade43ac97886a512b360d01d66be9f41f3c61088b42cedf92e03d678"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "bitflags",
  "serde",
 ]
@@ -3454,18 +3535,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3474,11 +3555,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
 dependencies = [
- "itoa 0.4.7",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
@@ -3527,9 +3608,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.9.4"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad9fdbb69badc8916db738c25efd04f0a65297d26c2f8de4b62e57b8c12bc72"
+checksum = "ad6056b4cb69b6e43e3a0f055def223380baecc99da683884f205bf347f7c4b3"
 dependencies = [
  "rustversion",
  "serde",
@@ -3538,9 +3619,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "1.4.2"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1569374bd54623ec8bd592cf22ba6e03c0f177ff55fbc8c29a49e296e7adecf"
+checksum = "12e47be9471c72889ebafb5e14d5ff930d89ae7a67bbdb5f8abb564f845a927e"
 dependencies = [
  "darling 0.13.0",
  "proc-macro2",
@@ -4218,6 +4299,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4410,7 +4497,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc90836a84cb72e6934137b1504d0cae304ef5d83904beb0c8d773bbfe256ed"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "chrono",
  "data-encoding",
  "der-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,10 @@ members = [
   "merino-integration-tests",
   "merino-suggest",
   "merino-web",
+  "merino-wikipedia",
   "merino",
 ]
+default-members = ["merino"]
 
 [profile.release]
 # Enables line numbers in Sentry reporting

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -13,6 +13,10 @@ remote_settings:
   default_bucket: main
   default_collection: quicksuggest
 
+elasticsearch:
+  connection:
+    Type: none
+
 logging:
   levels: [INFO]
   format: compact

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -15,7 +15,7 @@ remote_settings:
 
 elasticsearch:
   connection:
-    Type: none
+    type: none
 
 logging:
   levels: [INFO]

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -36,3 +36,16 @@ services:
       - "8889:80"
     volumes:
       - ./.kinto-attachments:/usr/local/apache2/htdocs/
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.3
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      - discovery.type=single-node
+    volumes:
+     - elasticsearch-data:/usr/share/elasticsearch/data
+
+volumes:
+  elasticsearch-data:

--- a/merino-settings/src/lib.rs
+++ b/merino-settings/src/lib.rs
@@ -302,7 +302,7 @@ pub struct ElasticsearchSettings {
 
 #[serde_as]
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(tag = "Type", rename_all = "snake_case")]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum ElasticsearchConnection {
     Single {
         #[serde_as(as = "DisplayFromStr")]

--- a/merino-settings/src/lib.rs
+++ b/merino-settings/src/lib.rs
@@ -295,7 +295,7 @@ pub enum ProviderSettings {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(tag = "Type", rename_all = "snake_case")]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub struct ElasticsearchSettings {
     pub connection: ElasticsearchConnection,
 }

--- a/merino-settings/src/lib.rs
+++ b/merino-settings/src/lib.rs
@@ -94,6 +94,8 @@ pub struct Settings {
     /// off, the suggest request object should be logged, but the
     /// search query should be blank.
     pub log_full_request: bool,
+
+    pub elasticsearch: ElasticsearchSettings,
 }
 
 /// Settings for the HTTP server.
@@ -290,6 +292,26 @@ pub enum ProviderSettings {
 
     /// A remote source behind an HTTP endpoint. This is used for production.
     Remote { uri: String },
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "Type", rename_all = "snake_case")]
+pub struct ElasticsearchSettings {
+    pub connection: ElasticsearchConnection,
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "Type", rename_all = "snake_case")]
+pub enum ElasticsearchConnection {
+    Single {
+        #[serde_as(as = "DisplayFromStr")]
+        url: Uri,
+    },
+    Cloud {
+        cloud_id: String,
+    },
+    None,
 }
 
 impl Settings {

--- a/merino-wikipedia/Cargo.toml
+++ b/merino-wikipedia/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "merino-wikipedia"
+version = "0.5.1"
+edition = "2021"
+
+[dependencies]
+anyhow = "1.0.53"
+elasticsearch = "7.14.0-alpha.1"
+serde = { version = "1.0.136", features = ["derive"] }
+serde_json = "1.0.78"
+serde_with = "1.11.0"
+tokio = { version = "1.15.0", features = ["full"] }
+merino-settings = { path = "../merino-settings" }
+
+[[bin]]
+name = "elasticsearch-demo"
+path = "src/demo.rs"

--- a/merino-wikipedia/src/demo.rs
+++ b/merino-wikipedia/src/demo.rs
@@ -1,0 +1,24 @@
+use anyhow::{Context, Result};
+use merino_wikipedia::{ElasticHelper, WikipediaDocument, WikipediaNamespace};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let settings = merino_settings::Settings::load()
+        .await
+        .context("Loading settings")?;
+
+    let es_client = ElasticHelper::new(&settings.elasticsearch, "merino-scratch")?;
+
+    es_client.index_ensure_exists().await?;
+
+    let doc = WikipediaDocument {
+        title: "A Test Page".to_string(),
+        page_text: "There is some stuff here, probably.".to_string(),
+        namespace: WikipediaNamespace::Article,
+        page_id: 0,
+    };
+
+    es_client.doc_add(doc).await?;
+
+    Ok(())
+}

--- a/merino-wikipedia/src/domain.rs
+++ b/merino-wikipedia/src/domain.rs
@@ -1,0 +1,137 @@
+//! Data types used to define the data this crate works with;
+
+use anyhow::anyhow;
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, TryFromInto};
+
+/// A page on Wikipedia. This type is a partial
+#[serde_as]
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct WikipediaDocument {
+    /// The human readable title of the page.
+    pub title: String,
+
+    /// The contents of the page, in Wikitext.
+    pub page_text: String,
+
+    /// The Wikipedia namespace of the page.
+    #[serde_as(as = "TryFromInto<i32>")]
+    pub namespace: WikipediaNamespace,
+
+    /// The Wikipedia ID for this page. It is expected that if two pages have
+    /// the same page_id, they are the same page, with possible edits.
+    pub page_id: u32,
+}
+
+///
+#[allow(missing_docs, clippy::missing_docs_in_private_items)]
+#[derive(Clone, Copy, Debug)]
+pub enum WikipediaNamespace {
+    Article,
+    ArticleTalk,
+    User,
+    UserTalk,
+    Wikipedia,
+    WikipediaTalk,
+    File,
+    FileTalk,
+    MediaWiki,
+    MediaWikiTalk,
+    Template,
+    TemplateTalk,
+    Help,
+    HelpTalk,
+    Category,
+    CategoryTalk,
+    Portal,
+    PortalTalk,
+    Draft,
+    DraftTalk,
+    TimedText,
+    TimedTextTalk,
+    Module,
+    ModuleTalk,
+    Gadget,
+    GadgetTalk,
+    GadgetDefinition,
+    GadgetDefinitionTalk,
+    Special,
+    Media,
+}
+
+impl TryFrom<i32> for WikipediaNamespace {
+    type Error = anyhow::Error;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(Self::Article),
+            1 => Ok(Self::ArticleTalk),
+            2 => Ok(Self::User),
+            3 => Ok(Self::UserTalk),
+            4 => Ok(Self::Wikipedia),
+            5 => Ok(Self::WikipediaTalk),
+            6 => Ok(Self::File),
+            7 => Ok(Self::FileTalk),
+            8 => Ok(Self::MediaWiki),
+            9 => Ok(Self::MediaWikiTalk),
+            10 => Ok(Self::Template),
+            11 => Ok(Self::TemplateTalk),
+            12 => Ok(Self::Help),
+            13 => Ok(Self::HelpTalk),
+            14 => Ok(Self::Category),
+            15 => Ok(Self::CategoryTalk),
+            100 => Ok(Self::Portal),
+            101 => Ok(Self::PortalTalk),
+            118 => Ok(Self::Draft),
+            119 => Ok(Self::DraftTalk),
+            710 => Ok(Self::TimedText),
+            711 => Ok(Self::TimedTextTalk),
+            828 => Ok(Self::Module),
+            829 => Ok(Self::ModuleTalk),
+            2300 => Ok(Self::Gadget),
+            2301 => Ok(Self::GadgetTalk),
+            2302 => Ok(Self::GadgetDefinition),
+            2303 => Ok(Self::GadgetDefinitionTalk),
+            -1 => Ok(Self::Special),
+            -2 => Ok(Self::Media),
+            _ => Err(anyhow!("Unexpected namespace ID {value}")),
+        }
+    }
+}
+
+impl From<WikipediaNamespace> for i32 {
+    fn from(ns: WikipediaNamespace) -> Self {
+        match ns {
+            WikipediaNamespace::Article => 0,
+            WikipediaNamespace::ArticleTalk => 1,
+            WikipediaNamespace::User => 2,
+            WikipediaNamespace::UserTalk => 3,
+            WikipediaNamespace::Wikipedia => 4,
+            WikipediaNamespace::WikipediaTalk => 5,
+            WikipediaNamespace::File => 6,
+            WikipediaNamespace::FileTalk => 7,
+            WikipediaNamespace::MediaWiki => 8,
+            WikipediaNamespace::MediaWikiTalk => 9,
+            WikipediaNamespace::Template => 10,
+            WikipediaNamespace::TemplateTalk => 11,
+            WikipediaNamespace::Help => 12,
+            WikipediaNamespace::HelpTalk => 13,
+            WikipediaNamespace::Category => 14,
+            WikipediaNamespace::CategoryTalk => 15,
+            WikipediaNamespace::Portal => 100,
+            WikipediaNamespace::PortalTalk => 101,
+            WikipediaNamespace::Draft => 118,
+            WikipediaNamespace::DraftTalk => 119,
+            WikipediaNamespace::TimedText => 710,
+            WikipediaNamespace::TimedTextTalk => 711,
+            WikipediaNamespace::Module => 828,
+            WikipediaNamespace::ModuleTalk => 829,
+            WikipediaNamespace::Gadget => 2300,
+            WikipediaNamespace::GadgetTalk => 2301,
+            WikipediaNamespace::GadgetDefinition => 2302,
+            WikipediaNamespace::GadgetDefinitionTalk => 2303,
+            WikipediaNamespace::Special => -1,
+            WikipediaNamespace::Media => -2,
+        }
+    }
+}

--- a/merino-wikipedia/src/domain.rs
+++ b/merino-wikipedia/src/domain.rs
@@ -23,7 +23,10 @@ pub struct WikipediaDocument {
     pub page_id: u32,
 }
 
-///
+/// The namespace of a Wikipedia page. Included here for completeness, but all
+/// of the content we are interested are likely in namespace 0, Articles. This
+/// will be included in the Wikipedia data that we have access to, and is
+/// important to disambiguate page IDs.
 #[allow(missing_docs, clippy::missing_docs_in_private_items)]
 #[derive(Clone, Copy, Debug)]
 pub enum WikipediaNamespace {

--- a/merino-wikipedia/src/es_helper.rs
+++ b/merino-wikipedia/src/es_helper.rs
@@ -160,7 +160,7 @@ impl ElasticHelper {
     }
 }
 
-/// An object that can be indexed using [`ElasticHelper`].  pub trait HelperIndexable: Serialize {
+/// An object that can be indexed using [`ElasticHelper`].
 pub trait HelperIndexable: Serialize {
     /// The ID that this document should be indexed under. Two documents with
     /// the same ID are considered to be semantically equivalent. If a document

--- a/merino-wikipedia/src/es_helper.rs
+++ b/merino-wikipedia/src/es_helper.rs
@@ -1,0 +1,180 @@
+//! Helpers to make working with the ES API easier. Customized specifically for
+//! our use case and Wikipedia content.
+
+use anyhow::{bail, Context, Result};
+use elasticsearch::{
+    http::transport::{CloudConnectionPool, SingleNodeConnectionPool, TransportBuilder},
+    indices::{IndicesCreateParts, IndicesExistsParts},
+    Elasticsearch, IndexParts,
+};
+use serde::Serialize;
+use serde_json::json;
+
+use crate::{WikipediaDocument, WikipediaNamespace};
+
+/// A wrapper around an Elasticsearch client to make common operations easier
+/// and more consistent.
+pub struct ElasticHelper {
+    /// The ES client this helper users.
+    pub client: Elasticsearch,
+    /// The search index this helper targets.
+    pub index_name: String,
+}
+
+impl ElasticHelper {
+    /// Create a new ElasticHelper that connects to the server specified in
+    /// `settings` and uses the index specified in [`index_name`].
+    ///
+    /// # Errors
+    /// If the settings to connect to Elasticsearch are not valid, the creation
+    /// process may fail.
+    pub fn new<S: Into<String>>(
+        es_settings: &merino_settings::ElasticsearchSettings,
+        index_name: S,
+    ) -> Result<Self> {
+        let transport_builder = match &es_settings.connection {
+            merino_settings::ElasticsearchConnection::Single { url } => {
+                TransportBuilder::new(SingleNodeConnectionPool::new(
+                    elasticsearch::http::Url::parse(&url.to_string())
+                        .context("Could not parse Elasticsearch URL")?,
+                ))
+            }
+            merino_settings::ElasticsearchConnection::Cloud { cloud_id } => TransportBuilder::new(
+                CloudConnectionPool::new(cloud_id)
+                    .context("Could not create Elasticsearch cloud connection")?,
+            ),
+            merino_settings::ElasticsearchConnection::None => {
+                bail!("Elasticsearch is not configured")
+            }
+        };
+
+        let transport = transport_builder
+            .build()
+            .context("misconfigured elasticsearch")?;
+
+        let client = Elasticsearch::new(transport);
+
+        Ok(Self {
+            client,
+            index_name: index_name.into(),
+        })
+    }
+
+    /// Check that the helper's index exists.
+    /// # Errors
+    /// If there is an HTTP error communication with ES.
+    pub async fn index_exists(&self) -> Result<bool> {
+        let exists_res = self
+            .client
+            .indices()
+            .exists(IndicesExistsParts::Index(&[&self.index_name]))
+            .send()
+            .await
+            .context(format!("index_exists({}) request", self.index_name))?;
+        match exists_res.status_code().as_u16() {
+            200 => Ok(true),
+            404 => Ok(false),
+            code => {
+                let exists_output = exists_res
+                    .text()
+                    .await
+                    .context("Fetching text of exists command")?;
+                Err(anyhow::anyhow!(
+                    "Unexpected status code from index_exists({}) {code}. Error: {exists_output}",
+                    self.index_name
+                ))
+            }
+        }
+    }
+
+    /// Creates the helper's index, assuming it doesn't already exist.
+    /// # Errors
+    /// If the index already exists, or if there is an HTTP error communication with ES.
+    pub async fn index_create(&self) -> Result<()> {
+        let create_res = self
+            .client
+            .indices()
+            .create(IndicesCreateParts::Index(&self.index_name))
+            .body(json!({
+                "mappings": {
+                    "_source": {
+                        "excludes": ["page_text"],
+                    },
+                    "properties": {
+                        "title": {"type": "text", "store": true, "analyzer": "english"},
+                        "page_text": {"type": "search_as_you_type", "store": false, "analyzer": "english"},
+                        "url": {"type": "keyword", "index": false, "store": true},
+                        "namespace_id": {"type": "keyword", "index": false},
+                        "page_id": {"type": "keyword", "index": false},
+                    }
+                }
+            }))
+            .send()
+            .await
+            .context(format!("index_create({}) request", self.index_name))?;
+
+        let status = create_res.status_code();
+        if status.is_success() {
+            Ok(())
+        } else {
+            let exists_output = create_res
+                .text()
+                .await
+                .context("Fetching text of exists command")?;
+            Err(anyhow::anyhow!(
+                "Unexpected status code from index_create({}) {}. Error: {exists_output}",
+                self.index_name,
+                status.as_u16(),
+            ))
+        }
+    }
+
+    /// Ensure that the helper's index exists, creating it if needed.
+    /// # Errors
+    /// If there is an HTTP error communication with ES.
+    pub async fn index_ensure_exists(&self) -> Result<()> {
+        if !self.index_exists().await? {
+            self.index_create().await?;
+        }
+        Ok(())
+    }
+
+    /// Add a document to the helper's index. The ID of the document will be set
+    /// based on the [`HelperIndexable::doc_id`] method.
+    ///
+    /// # Errors
+    /// If there is an HTTP error communication with ES, or if there is a
+    /// problem serializing the document.
+    pub async fn doc_add<T>(&self, doc: T) -> Result<()>
+    where
+        T: HelperIndexable,
+    {
+        let doc_id = doc.doc_id();
+        self.client
+            .index(IndexParts::IndexId(&self.index_name, &doc_id))
+            .body(doc)
+            .send()
+            .await
+            .context("indexing doc request")?;
+        Ok(())
+    }
+}
+
+/// An object that can be indexed using [`ElasticHelper`].  pub trait HelperIndexable: Serialize {
+pub trait HelperIndexable: Serialize {
+    /// The ID that this document should be indexed under. Two documents with
+    /// the same ID are considered to be semantically equivalent. If a document
+    /// with the given ID is already present in the search index, it will be
+    /// overridden if another document with the same ID is added.
+    fn doc_id(&self) -> String;
+}
+
+impl HelperIndexable for WikipediaDocument {
+    fn doc_id(&self) -> String {
+        format!(
+            "wikidoc/{}/{}",
+            <i32 as From<WikipediaNamespace>>::from(self.namespace),
+            self.page_id
+        )
+    }
+}

--- a/merino-wikipedia/src/lib.rs
+++ b/merino-wikipedia/src/lib.rs
@@ -1,0 +1,10 @@
+//! Tools to process Wikipedia data into a search index, and to create a
+//! Suggestion provider that queries that index.
+
+#![warn(missing_docs, clippy::missing_docs_in_private_items)]
+
+mod domain;
+mod es_helper;
+
+pub use domain::{WikipediaDocument, WikipediaNamespace};
+pub use es_helper::ElasticHelper;


### PR DESCRIPTION
Consider using `cargo run --bin elasticsearch-demo` to test indexing a simple document into ES.
