### PR TITLE
refactor(integration-tests-macro): Refactor the merino_test macro

### DIFF
--- a/merino-integration-tests-macro/src/lib.rs
+++ b/merino-integration-tests-macro/src/lib.rs
@@ -228,7 +228,6 @@ fn parse_settings_body(
                     "only `val: Type` parameters can be used for merino_test settings inputs",
                 )
                 .into_compile_error()
-                .into()
             }
         }
     }


### PR DESCRIPTION
Nothing particular changed, just broke the original marco down into several smaller pieces for better readability.