### PR TITLE
test: add an integration test for redis reconfigure

### DIFF
--- a/merino-cache/src/redis/mod.rs
+++ b/merino-cache/src/redis/mod.rs
@@ -433,7 +433,7 @@ impl SuggestionProvider for Suggester {
     ///
     /// Note that the reconfiguration will _not_ wipe out the Redis cache.
     /// It only reconfigures the inner provider and other cache settings such
-    /// as `default_ttl` for the subsequent cache operatoins.
+    /// as `default_ttl` for the subsequent cache operations.
     async fn reconfigure(
         &mut self,
         new_config: serde_json::Value,

--- a/merino-cache/src/redis/mod.rs
+++ b/merino-cache/src/redis/mod.rs
@@ -429,6 +429,11 @@ impl SuggestionProvider for Suggester {
         Ok(rv)
     }
 
+    /// Reconfigure the Redis provider.
+    ///
+    /// Note that the reconfiguration will _not_ wipe out the Redis cache.
+    /// It only reconfigures the inner provider and other cache settings such
+    /// as `default_ttl` for the subsequent cache operatoins.
     async fn reconfigure(
         &mut self,
         new_config: serde_json::Value,

--- a/merino-integration-tests/src/caching/redis_tests.rs
+++ b/merino-integration-tests/src/caching/redis_tests.rs
@@ -2,10 +2,11 @@
 #![cfg(test)]
 
 use crate::{merino_test_macro, TestingTools};
-use merino_settings::providers::{RedisCacheConfig, SuggestionProviderConfig};
+use merino_settings::providers::{FixedConfig, RedisCacheConfig, SuggestionProviderConfig};
 use redis::Commands;
 use reqwest::{header::HeaderValue, StatusCode};
 use serde_json::Value;
+use std::collections::HashMap;
 use std::time::Duration;
 
 #[merino_test_macro(|settings| {
@@ -196,4 +197,93 @@ async fn get_cached_key(
         }
     })
     .await
+}
+
+#[merino_test_macro(|settings| {
+    settings.debug = true;
+    settings.suggestion_providers.insert(
+        "fixed_redis".to_string(),
+        SuggestionProviderConfig::RedisCache(RedisCacheConfig::with_inner(
+            SuggestionProviderConfig::Fixed(FixedConfig { value: "foo".to_owned() })
+        )),
+    );
+})]
+async fn test_reconfigure(
+    TestingTools {
+        test_client,
+        mut redis_client,
+        ..
+    }: TestingTools,
+) {
+    let keys_before: Vec<String> = redis_client
+        .keys("provider:v1:*")
+        .expect("Could not get keys from redis");
+    assert!(keys_before.is_empty());
+
+    let response = test_client
+        .get("/api/v1/suggest?q=foo")
+        .send()
+        .await
+        .expect("failed to execute request");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Prepare for updating the inner provider.
+    // Reset the inner `FixedProvider` also reduce the `default_ttl`.
+    let mut redis_config =
+        RedisCacheConfig::with_inner(SuggestionProviderConfig::Fixed(FixedConfig {
+            value: "bar".to_owned(),
+        }));
+    redis_config.default_ttl = Duration::from_secs(1);
+    let new_config: HashMap<String, SuggestionProviderConfig> = [(
+        "fixed_redis".to_owned(),
+        SuggestionProviderConfig::RedisCache(redis_config),
+    )]
+    .into_iter()
+    .collect();
+
+    // Request for a reconfigure for Redis provider.
+    // Note that this reconfigure endpoint is only exposed in debug mode.
+    let response = test_client
+        .post("/api/v1/providers/reconfigure")
+        .json(&new_config)
+        .send()
+        .await
+        .expect("failed to execute request");
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    let response = test_client
+        .get("/api/v1/suggest?q=bar")
+        .send()
+        .await
+        .expect("failed to execute request");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Verify the new `FixedProvider` is in use.
+    let http_response: Value = response.json().await.expect("response was not json");
+    let http_suggestions = http_response["suggestions"].as_array().unwrap();
+    assert_eq!(http_suggestions.len(), 1);
+    assert_eq!(http_suggestions[0]["title"], "bar");
+
+    // Wait for a bit to let the newly inserted value expire.
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    // "bar" should not be in the cache as its key already expires.
+    let keys_after: Vec<String> = redis_client
+        .keys("provider:v1:*")
+        .expect("Could not get keys");
+    assert_eq!(
+        keys_after.len(),
+        1,
+        "Only one item should be left in the cache"
+    );
+
+    let encoded: String = redis_client
+        .get(&keys_after[0])
+        .expect("Could not get cached item");
+
+    let cache_suggestions: Vec<Value> =
+        serde_json::from_str(&encoded[2..]).expect("Couldn't parse cached item");
+    // The cached value should be the old one "foo".
+    assert_eq!(cache_suggestions[0]["title"], "foo");
 }

--- a/merino-integration-tests/src/utils/test_tools.rs
+++ b/merino-integration-tests/src/utils/test_tools.rs
@@ -234,6 +234,15 @@ impl TestReqwestClient {
         let url = format!("http://{}{}", &self.address, path);
         self.client.get(url)
     }
+
+    /// Start building a POST request to the test server with the path specified.
+    ///
+    /// The path should start with `/`, such as `/__heartbeat__`.
+    pub fn post(&self, path: &str) -> RequestBuilder {
+        assert!(path.starts_with('/'));
+        let url = format!("http://{}{}", &self.address, path);
+        self.client.post(url)
+    }
 }
 
 /// Set up Remote Settings with a new bucket and a new collection


### PR DESCRIPTION
This fixed [CONSVC-1618](https://mozilla-hub.atlassian.net/browse/CONSVC-1618).

The reconfigure for Redis provider was already implemented in #337, this added an integration for it. 