### PR TITLE
feat: provide a mechanism to prevent deploying

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,8 +276,10 @@ commands:
     steps:
       - run:
           name: Check if deployment is disallowed
+          # This relies on the [do not deploy] text to be available in the
+          # merge commit when merging the PR to 'main'.
           command: |
             if git log -1 "$CIRCLE_SHA1" | grep -q '\[do not deploy\]'; then
-                echo "Skipping this step: deployment was disabled in the last commit."
+                echo "Skipping this step: deployment was disabled in the PR."
                 circleci-agent step halt
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,6 +166,7 @@ jobs:
           password: $DOCKER_PASS
     steps:
       - checkout
+      - skip-if-do-not-deploy
       - setup_remote_docker
       - attach_workspace:
           at: workspace
@@ -270,3 +271,13 @@ commands:
             "$CIRCLE_PROJECT_USERNAME" \
             "$CIRCLE_PROJECT_REPONAME" \
             "$CIRCLE_BUILD_URL" > version.json
+
+  skip-if-do-not-deploy:
+    steps:
+      - run:
+          name: Check if deployment is disallowed
+          command: |
+            if git log -1 "$CIRCLE_SHA1" | grep -q '\[do not deploy\]'; then
+                echo "Skipping this step: deployment was disabled in the last commit."
+                circleci-agent step halt
+            fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,30 +57,6 @@ workflows:
             - docker-image-build
             - contract-tests
 
-  tag-workflow:
-    jobs:
-      - checks: &tag-filters
-          filters:
-            tags:
-              only: /v.*/
-            branches:
-              ignore: /.*/
-      - build-and-test:
-          <<: *tag-filters
-      - docker-image-build:
-          <<: *tag-filters
-      - contract-tests:
-          <<: *tag-filters
-          requires:
-            - docker-image-build
-      - docker-image-publish:
-          <<: *tag-filters
-          requires:
-            - checks
-            - build-and-test
-            - docker-image-build
-            - contract-tests
-
 jobs:
   checks:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,6 +280,6 @@ commands:
           # merge commit when merging the PR to 'main'.
           command: |
             if git log -1 "$CIRCLE_SHA1" | grep -q '\[do not deploy\]'; then
-                echo "Skipping this step: deployment was disabled in the PR."
+                echo "Skipping remaining steps in this job: deployment was disabled for this commit."
                 circleci-agent step halt
             fi

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -14,6 +14,7 @@
   - [Testing Strategies](./dev/testing.md)
   - [Merino Admin](./dev/admin.md)
   - [Merino Showroom](./dev/showroom.md)
+  - [Release Process](./dev/release-process.md)
 
 # Architecture Decision Records
 

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -6,7 +6,7 @@ This project currently follows a [Continuous Delivery][continuous_delivery] proc
 [continuous_deployment]: https://en.wikipedia.org/wiki/Continuous_deployment
 
 Whenever a commit is pushed to this repository's `main` branch, the deployment pipeline kicks in, deploying the changeset to the [`stage` environment](../firefox.md#stage).
-After the deployment is complete, accessing the [`__version__` endpoint][stage_version] will show the commit hash of the deployed version, which will match to the one of the latest commit on the `main` branch.
+After the deployment is complete, accessing the [`__version__` endpoint][stage_version] will show the commit hash of the deployed version, which will eventually match to the one of the latest commit on the `main` branch (a node with an older version might still serve the request before it is shut down).
 
 [stage_version]: https://stage.merino.nonprod.cloudops.mozgcp.net/__version__
 

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -5,7 +5,7 @@ This project currently follows a [Continuous Delivery][continuous_delivery] proc
 [continuous_delivery]: https://en.wikipedia.org/wiki/Continuous_delivery
 [continuous_deployment]: https://en.wikipedia.org/wiki/Continuous_deployment
 
-Whenever a commit is merged to this repository's `main` branch, the deployment pipeline kicks in, deploying the changeset to the [`stage` environment](../firefox.md#stage).
+Whenever a commit is pushed to this repository's `main` branch, the deployment pipeline kicks in, deploying the changeset to the [`stage` environment](../firefox.md#stage).
 After the deployment is complete, accessing the [`__version__` endpoint][stage_version] will show the commit hash of the deployed version, which will match to the one of the latest commit on the `main` branch.
 
 [stage_version]: https://stage.merino.nonprod.cloudops.mozgcp.net/__version__

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -2,7 +2,7 @@
 
 This project currently follows a [Continuous Delivery](https://en.wikipedia.org/wiki/Continuous_delivery) process, but it's gradually moving toward [Continuous Deployment](https://en.wikipedia.org/wiki/Continuous_deployment).
 
-Whenever a commit is merged to this repository's `main` branch, the deployment pipeline kicks in, deploying the changeset to the [`stage` environment](../firefox.md).
+Whenever a commit is merged to this repository's `main` branch, the deployment pipeline kicks in, deploying the changeset to the [`stage` environment](../firefox.md#stage).
 After the deployment is complete, accessing the [`__version__` endpoint](https://stage.merino.nonprod.cloudops.mozgcp.net/__version__) will show the commit hash of the deployed version, which will match to the one of the latest commit on the `main` branch.
 
 ## Versioning
@@ -10,7 +10,15 @@ The commit hash of the deployed code is considered its version identifier.
 
 ## Preventing deployment
 Occasionally developers might want to prevent a commit from triggering the deployment pipeline. While this should be discouraged, there are some legitimate cases for doing so (e.g. docs only changes).
-In order to prevent the deployment of the code from a PR when merging to `main`, the **title of that PR** must contain the `[do not deploy]` text.
+In order to prevent the deployment of the code from a PR when merging to `main`, the **title of that PR** must contain the `[do not deploy]` text. For example:
+
+```
+# PR title (NOT the commit message)
+doc: Add documentation for the release process [do not deploy]
+```
+
+While the `[do not deploy]` can be anywhere in the title, it is recommended to place it at its end in order to better integrate with the current PR title practices.
+
 The deployment pipeline will analyse the message of the merge commit (which will be contain the PR title) and make a decision based on it.
 
 ## Releasing to production

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -1,16 +1,22 @@
 # The Release Process
 
-This project currently follows a [Continuous Delivery](https://en.wikipedia.org/wiki/Continuous_delivery) process, but it's gradually moving toward [Continuous Deployment](https://en.wikipedia.org/wiki/Continuous_deployment).
+This project currently follows a [Continuous Delivery][continuous_delivery] process, but it's gradually moving toward [Continuous Deployment][continuous_deployment].
+
+[continuous_delivery]: https://en.wikipedia.org/wiki/Continuous_delivery
+[continuous_deployment]: https://en.wikipedia.org/wiki/Continuous_deployment
 
 Whenever a commit is merged to this repository's `main` branch, the deployment pipeline kicks in, deploying the changeset to the [`stage` environment](../firefox.md#stage).
-After the deployment is complete, accessing the [`__version__` endpoint](https://stage.merino.nonprod.cloudops.mozgcp.net/__version__) will show the commit hash of the deployed version, which will match to the one of the latest commit on the `main` branch.
+After the deployment is complete, accessing the [`__version__` endpoint][stage_version] will show the commit hash of the deployed version, which will match to the one of the latest commit on the `main` branch.
+
+[stage_version]: https://stage.merino.nonprod.cloudops.mozgcp.net/__version__
 
 ## Versioning
-The commit hash of the deployed code is considered its version identifier.
+The commit hash of the deployed code is considered its version identifier. The commit hash can be retrieved locally via `git rev-parse HEAD`.
 
 ## Preventing deployment
 Occasionally developers might want to prevent a commit from triggering the deployment pipeline. While this should be discouraged, there are some legitimate cases for doing so (e.g. docs only changes).
-In order to prevent the deployment of the code from a PR when merging to `main`, the **title of that PR** must contain the `[do not deploy]` text. For example:
+In order to prevent the deployment of the code from a PR when merging to `main`, the **title of that PR** must contain the `[do not deploy]` text. Note that, when generating the merge commit for a branch within the GitHub UI, the extened description must not be changed or care must be taken to ensure that `[do not deploy]`  is still present.
+For example:
 
 ```
 # PR title (NOT the commit message)

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -10,8 +10,8 @@ The commit hash of the deployed code is considered its version identifier.
 
 ## Preventing deployment
 Occasionally developers might want to prevent a commit from triggering the deployment pipeline. While this should be discouraged, there are some legitimate cases for doing so (e.g. docs only changes).
-In order to prevent the deployment of the code from a PR when merging to `main`, the **latest commit in the stack** must contain the `[do not deploy]` text.
-The deployment pipeline will analyse the message of the last commit and make a decision based on it.
+In order to prevent the deployment of the code from a PR when merging to `main`, the **title of that PR** must contain the `[do not deploy]` text.
+The deployment pipeline will analyse the message of the merge commit (which will be contain the PR title) and make a decision based on it.
 
 ## Releasing to production
 The process to promote a build from `stage` to `production` is currently manually initiated by SRE.

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -1,0 +1,18 @@
+# The Release Process
+
+This project currently follows a [Continuous Delivery](https://en.wikipedia.org/wiki/Continuous_delivery) process, but it's gradually moving toward [Continuous Deployment](https://en.wikipedia.org/wiki/Continuous_deployment).
+
+Whenever a commit is merged to this repository's `main` branch, the deployment pipeline kicks in, deploying the changeset to the [`stage` environment](../firefox.md).
+After the deployment is complete, accessing the [`__version__` endpoint](https://stage.merino.nonprod.cloudops.mozgcp.net/__version__) will show the commit hash of the deployed version, which will match to the one of the latest commit on the `main` branch.
+
+## Versioning
+The commit hash of the deployed code is considered its version identifier.
+
+## Preventing deployment
+Occasionally developers might want to prevent a commit from triggering the deployment pipeline. While this should be discouraged, there are some legitimate cases for doing so (e.g. docs only changes).
+In order to prevent the deployment of the code from a PR when merging to `main`, the **latest commit in the stack** must contain the `[do not deploy]` text.
+The deployment pipeline will analyse the message of the last commit and make a decision based on it.
+
+## Releasing to production
+The process to promote a build from `stage` to `production` is currently manually initiated by SRE.
+[This ticket](https://mozilla-hub.atlassian.net/browse/CONSVC-1566) (requires LDAP) deals with automating the process.


### PR DESCRIPTION
Fixes #339.

This introduces a mechanism to tag the latest commit in the PR in order to prevent deploying it to stage/prod.
In addition to that, it removes the deprecated release-tagging mechanism (we're now always deploying to stage, so we don't need to tag releases to do that) and documents the current release practices.

I added CI to a sample repo in my account, and here's how it works: [example](https://app.circleci.com/pipelines/github/Dexterp37/test_ci/17/workflows/ffddcb61-259a-4589-ad0f-0b243481b326/jobs/28)