### PR TITLE
Feat/308 send duration of mem cache to metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3102,9 +3102,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/docs/data.md
+++ b/docs/data.md
@@ -13,6 +13,10 @@ Any log containing sensitive data must include a boolean field `sensitive`
 that is set to `true` to exempt it from flowing to the generally accessible
 log inspection interfaces.
 
+- `cache.memory.remove-expired` - A record of expired entries for tracing framework 
+  for structured logging an diagnostics. Logs duration, removed pointers, and removed 
+  storage. 
+
 ### `merino-adm`
 
 - `INFO adm.remote-settings.sync-start` - The Remote Settings provider has
@@ -124,6 +128,9 @@ log inspection interfaces.
 
 - `cache.memory.pointers-len` - A gauge representing the number of entries in
   the first level of hashing in the in-memory deduped hashmap.
+
+- `cache.memory.duration` - A duration in milliseconds representing the time 
+  required for removal of expired entries.
 
 - `cache.memory.storage-len` - A gauge representing the number of entries in the
   second level of hashing in the in-memory deduped hashmap.

--- a/merino-suggest-providers/src/providers/keyword_filter.rs
+++ b/merino-suggest-providers/src/providers/keyword_filter.rs
@@ -265,8 +265,7 @@ mod tests {
         // Verify that the filtering was properly recorded.
         assert_eq!(rx.len(), 2);
         let collected_data: Vec<String> = rx
-            .iter()
-            .take(2)
+            .try_iter()
             .map(|x| String::from_utf8(x).unwrap())
             .collect();
         assert!(collected_data


### PR DESCRIPTION
This task added the `duration` variable - `Instant::now() - start` during memory cleanup phase so it can be ingested and viewed in our metrics. The `duration` variable is passed into the `.time_macros()` method under an instance of the `metrics_client`. 

The `time_macros()` function takes a a key and value pair and is capable of processing the duration struct, not requiring conversion using the rust time crate. The `.ok()` call at the end simply handles the conversion from `Result<T, E>` to the `Option<T>` to ensure the variable does not raise a compilation error of an unused variable. There was no tag addition required for this.

Also added documentation entries in the `data.md` file so the new key, as well as a missing key were added.