### PR TITLE
consvc-1670 - Enable deploying to production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ workflows:
             - checks
             - build-and-test
             - docker-image-build
-      - docker-image-publish:
+      - docker-image-publish-stage:
           <<: *main-filters
           requires:
             - checks
@@ -158,7 +158,7 @@ jobs:
            docker-compose -f test-engineering/contract-tests/docker-compose.yml build client kinto-setup
            docker-compose -f test-engineering/contract-tests/docker-compose.yml up --abort-on-container-exit
 
-  docker-image-publish:
+  docker-image-publish-stage:
     docker:
       - image: mozilla/cidockerbases:docker-latest
         auth:
@@ -179,10 +179,6 @@ jobs:
           command: |
             if [ "${CIRCLE_BRANCH}" == "main" ]; then
               DOCKER_TAG="${CIRCLE_SHA1}"
-            fi
-
-            if [ -n "${CIRCLE_TAG}" ]; then
-              DOCKER_TAG="$CIRCLE_TAG"
             fi
 
             if [ -n "${DOCKER_TAG}" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,22 @@ workflows:
             - build-and-test
             - docker-image-build
             - contract-tests
+      # The following job will require manual approval in the CircleCI web application.
+      # Once provided, and when all the requirements are fullfilled (e.g. tests)
+      - unhold-to-deploy-to-prod:
+          <<: *main-filters
+          type: approval
+          requires:
+            - checks
+            - build-and-test
+            - docker-image-build
+            - contract-tests
+      # On approval of the `unhold-to-deploy-to-prod` job, any successive job that requires it
+      # will run. In this case, it's manually triggering deployment to production. 
+      - docker-image-publish-prod:
+          <<: *main-filters
+          requires:
+            - unhold-to-deploy-to-prod
 
 jobs:
   checks:
@@ -179,6 +195,38 @@ jobs:
           command: |
             if [ "${CIRCLE_BRANCH}" == "main" ]; then
               DOCKER_TAG="${CIRCLE_SHA1}"
+            fi
+
+            if [ -n "${DOCKER_TAG}" ]; then
+              echo ${DOCKERHUB_REPO}:${DOCKER_TAG}
+              docker tag app:runtime ${DOCKERHUB_REPO}:${DOCKER_TAG}
+              docker images
+              docker push "${DOCKERHUB_REPO}:${DOCKER_TAG}"
+            else
+              echo "Not pushing to dockerhub for tag=${CIRCLE_TAG} branch=${CIRCLE_BRANCH}"
+            fi
+
+  docker-image-publish-prod:
+    docker:
+      - image: mozilla/cidockerbases:docker-latest
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
+    steps:
+      - checkout
+      - skip-if-do-not-deploy
+      - setup_remote_docker
+      - attach_workspace:
+          at: workspace
+      - dockerhub-login
+      - run:
+          name: Load Docker image from workspace
+          command: docker load -i workspace/merino.tar.gz
+      - run:
+          name: Push to Dockerhub (prod)
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "main" ]; then
+              DOCKER_TAG="prod-${CIRCLE_SHA1}"
             fi
 
             if [ -n "${DOCKER_TAG}" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,7 +191,7 @@ jobs:
           name: Load Docker image from workspace
           command: docker load -i workspace/merino.tar.gz
       - run:
-          name: Push to Dockerhub
+          name: Push to Docker Hub
           command: |
             if [ "${CIRCLE_BRANCH}" == "main" ]; then
               DOCKER_TAG="${CIRCLE_SHA1}"
@@ -223,7 +223,7 @@ jobs:
           name: Load Docker image from workspace
           command: docker load -i workspace/merino.tar.gz
       - run:
-          name: Push to Dockerhub (prod)
+          name: Push to Docker Hub (prod)
           command: |
             if [ "${CIRCLE_BRANCH}" == "main" ]; then
               DOCKER_TAG="prod-${CIRCLE_SHA1}"

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -28,9 +28,13 @@ While the `[do not deploy]` can be anywhere in the title, it is recommended to p
 The deployment pipeline will analyse the message of the merge commit (which will be contain the PR title) and make a decision based on it.
 
 ## Releasing to production
-Developers with write access to the Merino repository can initiate a deployment to production after a Pull-Request on the Merino GitHub repository is merged to the `main` branch. This can be done by:
+Developers with write access to the Merino repository can initiate a deployment to production after a Pull-Request on the Merino GitHub repository is merged to the `main` branch.
+While any developer with write access can trigger the deployment to production, the _expectation_ is that individual(s) who authored and merged the Pull-Request should do so, as they are the ones most familiar with their changes and who can tell, by looking at the data, if anything looks anomalous.
+In general authors should feel _responsible_ for the changes they make and shepherd throught their deployment.
 
-1. opening the [circleci dashboard][circleci_dashboard];
+Releasing to production can be done by:
+
+1. opening the [CircleCI dashboard][circleci_dashboard];
 2. looking up the pipeline named `merino <PR NUMBER>` running in the `main-workflow`; this pipeline should either be in a running status (if the required test jobs are still running) or in the "on hold" status, with the `unhold-to-deploy-to-prod` being held;
 3. once in the "on hold" status, with all the other jobs successfully completed, clicking on the "thumbs up" action on the `unhold-to-deploy-to-prod` job row will approve it and trigger the deployment, unblocking the `deploy-to-prod` job;
 4. developers **must** monitor the [Merino Application & Infrastructure][merino_app_info] dashboard for any anomaly, for example significant changes in HTTP response codes, increase in latency, cpu/memory usage (most things under the infrastructure heading).

--- a/docs/dev/release-process.md
+++ b/docs/dev/release-process.md
@@ -28,5 +28,27 @@ While the `[do not deploy]` can be anywhere in the title, it is recommended to p
 The deployment pipeline will analyse the message of the merge commit (which will be contain the PR title) and make a decision based on it.
 
 ## Releasing to production
-The process to promote a build from `stage` to `production` is currently manually initiated by SRE.
-[This ticket](https://mozilla-hub.atlassian.net/browse/CONSVC-1566) (requires LDAP) deals with automating the process.
+Developers with write access to the Merino repository can initiate a deployment to production after a Pull-Request on the Merino GitHub repository is merged to the `main` branch. This can be done by:
+
+1. opening the [circleci dashboard][circleci_dashboard];
+2. looking up the pipeline named `merino <PR NUMBER>` running in the `main-workflow`; this pipeline should either be in a running status (if the required test jobs are still running) or in the "on hold" status, with the `unhold-to-deploy-to-prod` being held;
+3. once in the "on hold" status, with all the other jobs successfully completed, clicking on the "thumbs up" action on the `unhold-to-deploy-to-prod` job row will approve it and trigger the deployment, unblocking the `deploy-to-prod` job;
+4. developers **must** monitor the [Merino Application & Infrastructure][merino_app_info] dashboard for any anomaly, for example significant changes in HTTP response codes, increase in latency, cpu/memory usage (most things under the infrastructure heading).
+
+[circleci_dashboard]: https://app.circleci.com/pipelines/github/mozilla-services/merino?branch=main&filter=all
+[merino_app_info]: https://earthangel-b40313e5.influxcloud.net/d/Cm83vS57z/merino-application-and-infrastructure?orgId=1&refresh=1m
+
+## What to do if production is broken?
+Don't panic and follow the instructions below:
+
+- depending on the severity of the problem, decide if this warrants [kicking off an incident][incident_docs];
+- if the root cause of the problem can be identified in a relatively small time, create a PR for the fix.
+    - verify the fix locally;
+    - verify the fix on `stage`, after it is reviewed by a Merino developer and merged;
+    - [deploy it to production](#releasing-to-production).
+
+**OR**
+
+- if the root cause of the problem is harder to track down, revert the last commit and then [deploy the revert commit to production](#releasing-to-production).
+
+[incident_docs]: https://mana.mozilla.org/wiki/pages/viewpage.action?pageId=150549987


### PR DESCRIPTION
This introduces the CircleCI facilities that are used to trigger deployment to production.

It also changes the release process documents to highlight the new release process.

Here's what the UI looks like (I tried this in my [toy repo](https://github.com/Dexterp37/test_ci)):

![image](https://user-images.githubusercontent.com/883721/158840463-1e5287c6-ea5e-4128-b3d0-19374779fa28.png)

Works toward, but does not fully fix, #352 (it still lacks the SRE changes on the pipeline side).