### PR TITLE
chore: add do-not-deploy for dependabot commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  # Merino Showroom
+  - package-ecosystem: "npm"
+    directory: "merino-showroom"
+    schedule:
+      interval: "daily"
+    commit-message:
+      # Add `[do not deploy]` to skip the auto deploy for this project
+      prefix: "[do not deploy]"


### PR DESCRIPTION
Dependency updates for `merino-showroom` do not need a deployment.