### PR TITLE
chore: Skip circleci approval task for do-not-deploy tags [do not deploy]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,7 +327,9 @@ commands:
                 echo "Skipping remaining steps in this job: deployment was disabled for this commit."
                 circleci-agent step halt
 
-                # No need to deploy, just cancel the rest of jobs of the workflow
+                # No need to deploy, just cancel the rest of jobs of the workflow.
+                # See API detail: https://circleci.com/docs/api/v2/index.html#operation/cancelWorkflow
+
                 curl -X POST https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/cancel \
                 -H 'Accept: application/json' \
                 -H 'Circle-Token: ${SKIP_DEPLOY_API_TOKEN}'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ workflows:
             - docker-image-build
             - contract-tests
       # On approval of the `unhold-to-deploy-to-prod` job, any successive job that requires it
-      # will run. In this case, it's manually triggering deployment to production. 
+      # will run. In this case, it's manually triggering deployment to production.
       - docker-image-publish-prod:
           <<: *main-filters
           requires:
@@ -326,4 +326,9 @@ commands:
             if git log -1 "$CIRCLE_SHA1" | grep -q '\[do not deploy\]'; then
                 echo "Skipping remaining steps in this job: deployment was disabled for this commit."
                 circleci-agent step halt
+
+                # No need to deploy, just cancel the rest of jobs of the workflow
+                curl -X POST https://circleci.com/api/v2/workflow/${CIRCLE_WORKFLOW_ID}/cancel \
+                -H 'Accept: application/json' \
+                -H 'Circle-Token: ${SKIP_DEPLOY_API_TOKEN}'
             fi


### PR DESCRIPTION
This fixes [CONSVC-1779](https://mozilla-hub.atlassian.net/browse/CONSVC-1779).

Turns out that `circle-agent step halt` works at the job level rather than at the workflow level, that's why CircleCI still processes the subsequent jobs. Per this [thread](https://discuss.circleci.com/t/does-circleci-step-halt-works-with-version-2-1/36674/2), we have to cancel the entire workflow which I think it's reasonable in our case.

cc: @hackebrot 