### PR TITLE
added request delay field with default and implementation in test_merino [do not deploy]

### DIFF
--- a/merino-cache/src/redis/domain.rs
+++ b/merino-cache/src/redis/domain.rs
@@ -66,7 +66,7 @@ impl From<RedisSuggestions> for Vec<Suggestion> {
 }
 
 /// The result from the Redis `TTL` command, converting the two error codes (-1 and -2) into enum variants.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum RedisTtl {
     /// The key requested does not exist.
     KeyDoesNotExist,

--- a/merino-settings/src/logging.rs
+++ b/merino-settings/src/logging.rs
@@ -68,7 +68,7 @@ pub enum LogFormat {
 ///strings.
 ///
 /// Every entry in this struct is guaranteed to be parsable as a valid Directive.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DirectiveWrapper(Vec<String>);
 
 impl Serialize for DirectiveWrapper {

--- a/merino-suggest-traits/src/device_info.rs
+++ b/merino-suggest-traits/src/device_info.rs
@@ -10,7 +10,7 @@ use serde::Serialize;
 use super::FIREFOX_TEST_VERSIONS;
 
 /// The form factor of the device that sent a given suggestion request.
-#[derive(Clone, Debug, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize)]
 pub enum FormFactor {
     /// A desktop computer.
     Desktop,
@@ -45,7 +45,7 @@ impl<F> fake::Dummy<F> for FormFactor {
 }
 
 /// Simplified Operating System Family
-#[derive(Clone, Debug, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize)]
 pub enum OsFamily {
     /// The Windows operating system.
     Windows,
@@ -97,7 +97,7 @@ impl<F> fake::Dummy<F> for OsFamily {
 }
 
 /// The web browser used to make a suggestion request.
-#[derive(Clone, Debug, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize)]
 pub enum Browser {
     /// The Firefox web browser with the major version number.
     Firefox(u32),

--- a/merino-suggest-traits/src/device_info.rs
+++ b/merino-suggest-traits/src/device_info.rs
@@ -124,7 +124,7 @@ impl<F> fake::Dummy<F> for Browser {
 }
 
 /// The user agent from a suggestion request.
-#[derive(Clone, Debug, Hash, PartialEq, Serialize)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize)]
 pub struct DeviceInfo {
     /// The operating system family indicated in the User-Agent header.
     pub os_family: OsFamily,

--- a/merino-suggest-traits/src/lib.rs
+++ b/merino-suggest-traits/src/lib.rs
@@ -136,7 +136,7 @@ impl<F> fake::Dummy<F> for SuggestionResponse {
 }
 
 /// The relation between an object and a cache.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CacheStatus {
     /// The object was pulled fresh from the cache.
     Hit,
@@ -351,7 +351,7 @@ pub enum SuggestError {
 }
 
 /// Languages supported by the client.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct SupportedLanguages(pub AcceptLanguage);
 
 impl SupportedLanguages {

--- a/test-engineering/contract-tests/client/README.md
+++ b/test-engineering/contract-tests/client/README.md
@@ -5,3 +5,11 @@ This directory contains a Python-based test framework for the contract tests.
 The HTTP client used in the framework requests suggestions from Merino and
 performs checks against the responses. The framework implements response models
 for the Merino API.
+
+#### Kinto Service
+* The optional delay can be defined to pause execution of requests to for suggestion refresh.
+
+
+
+#### Merino Service
+* The optional delay can be defined to pause execution of requests to for suggestion refresh.

--- a/test-engineering/contract-tests/client/tests/models.py
+++ b/test-engineering/contract-tests/client/tests/models.py
@@ -22,7 +22,7 @@ class Request(BaseModel):
     path: str
     headers: List[Header] = []
     # Delay is optional, providing time for data refresh
-    delay: Optional[int] = 0
+    delay: Optional[float] = 0
 
 
 class Suggestion(BaseModel, extra=Extra.allow):

--- a/test-engineering/contract-tests/client/tests/models.py
+++ b/test-engineering/contract-tests/client/tests/models.py
@@ -22,7 +22,7 @@ class Request(BaseModel):
     path: str
     headers: List[Header] = []
     # Delay is optional, providing time for data refresh
-    delay: Optional[float] = 0
+    delay: Optional[float] = None
 
 
 class Suggestion(BaseModel, extra=Extra.allow):

--- a/test-engineering/contract-tests/client/tests/models.py
+++ b/test-engineering/contract-tests/client/tests/models.py
@@ -21,6 +21,8 @@ class Request(BaseModel):
     method: str
     path: str
     headers: List[Header] = []
+    # Delay is optional, providing time for data refresh
+    delay: Optional[int] = 0
 
 
 class Suggestion(BaseModel, extra=Extra.allow):

--- a/test-engineering/contract-tests/client/tests/test_merino.py
+++ b/test-engineering/contract-tests/client/tests/test_merino.py
@@ -6,6 +6,7 @@
 from typing import Dict, List, Set, Tuple
 
 import pytest
+import time
 import requests
 from models import ResponseContent, Step, Suggestion
 
@@ -69,7 +70,8 @@ def assert_200_response(
 
         if "wiki_fruit" in suggestion.provider:
             # The icon URL is static for WikiFruit suggestions
-            expected_suggestion = expected_suggestions_by_id[suggestion_id(suggestion)]
+            expected_suggestion = expected_suggestions_by_id[suggestion_id(
+                suggestion)]
             assert suggestion.icon == expected_suggestion.icon
             continue
 
@@ -84,6 +86,11 @@ def test_merino(merino_url: str, steps: List[Step], kinto_icon_urls: Dict[str, s
         method = step.request.method
         url = f"{merino_url}{step.request.path}"
         headers = {header.name: header.value for header in step.request.headers}
+        delay = step.request.delay
+
+        # Process delay if defined in request model
+        if delay > 0:
+            time.sleep(delay)
 
         r = requests.request(method, url, headers=headers)
 

--- a/test-engineering/contract-tests/client/tests/test_merino.py
+++ b/test-engineering/contract-tests/client/tests/test_merino.py
@@ -89,7 +89,7 @@ def test_merino(merino_url: str, steps: List[Step], kinto_icon_urls: Dict[str, s
         delay = step.request.delay
 
         # Process delay if defined in request model
-        if delay > 0:
+        if (delay := step.request.delay) is not None:
             time.sleep(delay)
 
         r = requests.request(method, url, headers=headers)

--- a/test-engineering/contract-tests/client/tests/test_merino.py
+++ b/test-engineering/contract-tests/client/tests/test_merino.py
@@ -2,11 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
+import time
 from typing import Dict, List, Set, Tuple
 
 import pytest
-import time
+
 import requests
 from models import ResponseContent, Step, Suggestion
 


### PR DESCRIPTION
WIP

I followed the spec in the Pydantic docs [here](https://pydantic-docs.helpmanual.io/usage/models/#required-fields) and while there are some other ways to go about handing these optional fields, it can be can discussed them further based on your thoughts @Trinaa. I see the use of `default_factory` a few times which we could make use of given the hope of breaking up Merino and Kinto requests.  

I also saw something like this could work, however we don't want it to occur for each run of the test, but I wanted to point it out as an option nonetheless:
`@pytest.fixture(autouse=True)
def slow_down_tests():
    yield
    time.sleep(1)`

Post discussion and walking through both changes in our separate branches, we can move out of WIP status.