### PR TITLE
chore: update to the latest rust [do not deploy]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,12 +76,13 @@ workflows:
 jobs:
   checks:
     docker:
-      - image: mozilla/cidockerbases:rust-latest
+      - image: cimg/rust:1.63
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
     steps:
       - checkout
+      - setup-rust-check
       - rust-check
 
   build-and-test:
@@ -240,12 +241,16 @@ jobs:
 
   docs-build:
     docker:
-      - image: mozilla/cidockerbases:rust-latest
+      - image: cimg/rust:1.63
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
     steps:
       - checkout
+      - run:
+          name: Setup Build docs
+          command: |
+            cargo install mdbook
       - run:
           name: Build docs
           command: |
@@ -292,6 +297,13 @@ commands:
             else
               echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
             fi
+
+  setup-rust-check:
+    steps:
+      - run:
+          name: Setup Rust Checks
+          command: |
+            cargo install cargo-audit
 
   rust-check:
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG APT_CACHE_BUST="2021-05-13"
 # =============================================================================
 # Pull in the version of cargo-chef we plan to use, so that all the below steps
 # use a consistent set of versions.
-FROM lukemathwalker/cargo-chef:0.1.35-rust-1.61-buster as chef
+FROM lukemathwalker/cargo-chef:0.1.39-rust-1.63-buster as chef
 WORKDIR /app
 
 # =============================================================================


### PR DESCRIPTION
switching from the deprecated ci-docker-bases to cimg

and pin the rust version in ci, matching the Dockerfile

Closes #355