### PR TITLE
test: decouple kinto setup from client scenarios in merino contract tests [do not deploy]

### DIFF
--- a/config/ci.yaml
+++ b/config/ci.yaml
@@ -23,3 +23,4 @@ sentry:
 provider_settings:
   type: local
   path: ./config/providers/ci.yaml
+  cron_interval_sec: 2

--- a/config/providers/ci.yaml
+++ b/config/providers/ci.yaml
@@ -2,8 +2,7 @@
 test_wiki_fruit:
   type: wiki_fruit
 test_remote_settings:
-  type: memory_cache
-  inner:
-    type: remote_settings
-    collection: quicksuggest
-    suggestion_score: 0.3
+  type: remote_settings
+  collection: quicksuggest
+  suggestion_score: 0.3
+  resync_interval_sec: 1

--- a/test-engineering/contract-tests/client/tests/conftest.py
+++ b/test-engineering/contract-tests/client/tests/conftest.py
@@ -5,8 +5,7 @@
 import json
 import os
 import pathlib
-from functools import lru_cache
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List
 
 import pytest
 import yaml
@@ -73,28 +72,29 @@ def fixture_kinto_records(request: Any) -> Dict[str, KintoRecord]:
     return kinto_records
 
 
-@pytest.fixture(scope="session", name="kinto_icon_urls")
-def fixture_kinto_icon_urls(
+@pytest.fixture(scope="session", name="fetch_kinto_icon_url")
+def fixture_fetch_kinto_icon_url(
     request: Any,
     kinto_environment: KintoEnvironment,
     kinto_records: Dict[str, KintoRecord],
-) -> Dict[str, str]:
-    """Return a map from suggestion title to icon URL."""
+) -> Callable:
+    """Return a function that will query for an icon URL from a suggestion title"""
 
     attachments_url: str = request.config.option.kinto_attachments_url
 
-    @lru_cache(maxsize=None)
-    def fetch_icon_url(*, record_id: str) -> str:
+    def fetch_icon_url(*, suggestion_title: str) -> str:
         """Fetch the icon URL for the given Kinto record ID from Kinto."""
 
+        record_id: str = next(
+            f"icon-{suggestion.icon}"
+            for record in kinto_records.values()
+            for suggestion in record.attachment.suggestions
+            if suggestion.title == suggestion_title
+        )
         record: KintoRecord = get_record(kinto_environment, record_id)
         return f"{attachments_url}/{record.attachment.location}"
 
-    return {
-        suggestion.title: fetch_icon_url(record_id=f"icon-{suggestion.icon}")
-        for record in kinto_records.values()
-        for suggestion in record.attachment.suggestions
-    }
+    return fetch_icon_url
 
 
 def pytest_configure(config):

--- a/test-engineering/contract-tests/client/tests/test_merino.py
+++ b/test-engineering/contract-tests/client/tests/test_merino.py
@@ -49,7 +49,7 @@ def fixture_kinto_step(
 
 
 @pytest.fixture(scope="session", name="merino_step")
-def fixture_merino_step(merino_url: str, kinto_icon_urls: Dict[str, str]) -> Callable:
+def fixture_merino_step(merino_url: str, fetch_kinto_icon_url: Callable) -> Callable:
     """Define execution instructions for Merino scenario step."""
 
     def merino_step(step: Step) -> None:
@@ -79,7 +79,7 @@ def fixture_merino_step(merino_url: str, kinto_icon_urls: Dict[str, str]) -> Cal
             assert_200_response(
                 step_content=step.response.content,
                 merino_content=ResponseContent(**response.json()),
-                kinto_icon_urls=kinto_icon_urls,
+                fetch_kinto_icon_url=fetch_kinto_icon_url,
             )
             return
 
@@ -118,7 +118,7 @@ def assert_200_response(
     *,
     step_content: ResponseContent,
     merino_content: ResponseContent,
-    kinto_icon_urls: Dict[str, str],
+    fetch_kinto_icon_url: Callable,
 ) -> None:
     """Check that the content for a 200 OK response is what we expect."""
 
@@ -147,7 +147,10 @@ def assert_200_response(
     for suggestion in merino_content.suggestions:
         if "remote_settings" in suggestion.provider:
             # The icon URL is not static for RS suggestions
-            assert suggestion.icon == kinto_icon_urls[suggestion.title]
+            expected_suggestion_icon: str = fetch_kinto_icon_url(
+                suggestion_title=suggestion.title
+            )
+            assert suggestion.icon == expected_suggestion_icon
             continue
 
         if "wiki_fruit" in suggestion.provider:

--- a/test-engineering/contract-tests/docker-compose.yml
+++ b/test-engineering/contract-tests/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     environment:
       # The configuration preset to use
       MERINO__ENV: "ci"
+      MERINO__LOG_FULL_REQUEST: 'true'
       MERINO__REMOTE_SETTINGS__CRON_INTERVAL_SEC: 2
       MERINO__REMOTE_SETTINGS__DEFAULT_BUCKET: main
       MERINO__REMOTE_SETTINGS__DEFAULT_COLLECTION: quicksuggest

--- a/test-engineering/contract-tests/docker-compose.yml
+++ b/test-engineering/contract-tests/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
       # The configuration preset to use
       MERINO__ENV: "ci"
-      MERINO__REMOTE_SETTINGS__CRON_INTERVAL_SEC: 3
+      MERINO__REMOTE_SETTINGS__CRON_INTERVAL_SEC: 2
       MERINO__REMOTE_SETTINGS__DEFAULT_BUCKET: main
       MERINO__REMOTE_SETTINGS__DEFAULT_COLLECTION: quicksuggest
       MERINO__REMOTE_SETTINGS__RESYNC_INTERVAL_SEC: 1

--- a/test-engineering/contract-tests/docker-compose.yml
+++ b/test-engineering/contract-tests/docker-compose.yml
@@ -78,6 +78,5 @@ services:
       KINTO_URL: http://kinto:8888
       KINTO_BUCKET: main
       KINTO_COLLECTION: quicksuggest
-      KINTO_DATA_DIR: /tmp/kinto
     command: >
       /wait-for-it.sh kinto:8888 --strict -- python main.py

--- a/test-engineering/contract-tests/kinto-setup/README.md
+++ b/test-engineering/contract-tests/kinto-setup/README.md
@@ -9,4 +9,3 @@ Please set the following environment variables in `docker-compose.yml`:
 * `KINTO_URL`: The URL of the Kinto service
 * `KINTO_BUCKET`: The ID of the Kinto bucket to create
 * `KINTO_COLLECTION`: The ID of the Kinto collection to create
-* `KINTO_DATA_DIR`: The local directory containing Kinto data

--- a/test-engineering/contract-tests/kinto-setup/kinto.py
+++ b/test-engineering/contract-tests/kinto-setup/kinto.py
@@ -2,43 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import json
-from dataclasses import dataclass, field
-from typing import Dict, List, Set
-
 import requests
 import typer
-
-
-@dataclass
-class KintoAttachment:
-    """Class that holds information about an attachment in Kinto."""
-
-    filename: str
-    mimetype: str
-    filecontent: bytes
-    json_suggestions: List[Dict] = field(init=False)
-
-    def __post_init__(self):
-        """Load the JSON from the file content."""
-        self.json_suggestions = json.loads(self.filecontent)
-
-
-@dataclass
-class KintoRecord:
-    """Class that holds information about a record in Kinto."""
-
-    record_id: str
-    attachment: KintoAttachment
-    data_type: str
-
-    def __post_init__(self):
-        """Ensure the value of `data_type` is valid"""
-        if self.data_type not in ["data", "offline-expansion-data"]:
-            raise ValueError(
-                f"Invlid data type: {self.data_type},"
-                f" should be either 'data' or 'offline-expansion-data'."
-            )
 
 
 def create_bucket(*, api: str, bucket: str) -> None:
@@ -67,57 +32,3 @@ def create_collection(*, api: str, bucket: str, collection: str) -> None:
         },
     )
     response.raise_for_status()
-
-
-def upload_attachments(
-    *,
-    api: str,
-    bucket: str,
-    collection: str,
-    records: List[KintoRecord],
-) -> None:
-    """Upload attachments to Kinto for the given records."""
-    records_url = f"{api}/buckets/{bucket}/collections/{collection}/records"
-
-    for record in records:
-        typer.echo(f"uploading attachment for {record.record_id=}")
-
-        response = requests.post(
-            url=f"{records_url}/{record.record_id}/attachment",
-            files={
-                "attachment": (
-                    record.attachment.filename,
-                    record.attachment.filecontent,
-                    record.attachment.mimetype,
-                ),
-                "data": (None, f'{{"type": "{record.data_type}"}}'),
-            },
-        )
-        response.raise_for_status()
-
-
-def upload_icons(
-    *,
-    api: str,
-    bucket: str,
-    collection: str,
-    icon_ids: Set[str],
-) -> None:
-    """Upload icon attachments to Kinto for the given IDs."""
-    records_url = f"{api}/buckets/{bucket}/collections/{collection}/records"
-
-    for icon_id in icon_ids:
-        typer.echo(f"uploading icon for {icon_id=}")
-
-        response = requests.post(
-            url=f"{records_url}/icon-{icon_id}/attachment",
-            files={
-                "attachment": (
-                    f"icon-{icon_id}.png",
-                    f"icon-{icon_id}",
-                    "image/png",
-                ),
-                "data": (None, '{"type": "icon"}'),
-            },
-        )
-        response.raise_for_status()

--- a/test-engineering/contract-tests/volumes/client/scenarios.yml
+++ b/test-engineering/contract-tests/volumes/client/scenarios.yml
@@ -101,6 +101,15 @@ scenarios:
     description: Test that Merino successfully returns a Remote Settings suggestion
     steps:
       - request:
+          service: kinto
+          filename: "data-01.json"
+          data_type: "data"
+      - request:
+          service: kinto
+          filename: "data-02.json"
+          data_type: "data"
+      - request:
+          delay: 3 # Wait for remote settings data to load into merino
           service: merino
           method: GET
           path: '/api/v1/suggest?q=coffee'
@@ -133,6 +142,19 @@ scenarios:
     description: Test that Merino successfully returns a Remote Settings suggestion for Offline Expansion
     steps:
       - request:
+          service: kinto
+          filename: "data-01.json"
+          data_type: "data"
+      - request:
+          service: kinto
+          filename: "data-02.json"
+          data_type: "data"
+      - request:
+          service: kinto
+          filename: "offline-expansion-data-01.json"
+          data_type: "offline-expansion-data"
+      - request:
+          delay: 3 # Wait for remote settings data to load into merino
           service: merino
           method: GET
           path: '/api/v1/suggest?q=orange'
@@ -163,6 +185,15 @@ scenarios:
     description: Test that Merino successfully returns suggestions from multiple providers
     steps:
       - request:
+          service: kinto
+          filename: "data-01.json"
+          data_type: "data"
+      - request:
+          service: kinto
+          filename: "data-02.json"
+          data_type: "data"
+      - request:
+          delay: 3  # Wait for remote settings data to load into merino
           service: merino
           method: GET
           path: '/api/v1/suggest?q=banana'


### PR DESCRIPTION
## Description
* remove logic to upload attachments and icons from kinto-setup
* initialize record data in client scenario.yml steps
* update `MERINO__REMOTE_SETTINGS__CRON_INTERVAL_SEC` with value '2'
* add `MERINO__LOG_FULL_REQUEST` with value 'true'

## Issue(s)
[CONSVC-1939](https://mozilla-hub.atlassian.net/browse/CONSVC-1939)