### PR TITLE
feat: Add a timeout configuration for Remote Settings

### DIFF
--- a/config/base.yaml
+++ b/config/base.yaml
@@ -13,6 +13,7 @@ remote_settings:
   default_bucket: main
   default_collection: quicksuggest
   cron_interval_sec: 60
+  http_timeout_sec: 3
 
 elasticsearch:
   connection:

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -13,7 +13,8 @@ remote_settings:
   default_bucket: main
   default_collection: quicksuggest
   cron_interval_sec: 60
-  http_timeout_sec: 3
+  http_request_timeout_sec: 3
+  http_connect_timeout_sec: 10
 
 elasticsearch:
   connection:

--- a/docs/ops.md
+++ b/docs/ops.md
@@ -163,6 +163,10 @@ provider below.
     than `resync_interval_sec` of the Remote Settings leaf provider.
   - Retry if the regular resync fails.
 
+- `remote_settings.http_timeout_sec`
+  (`MERINO__REMOTE_SETTINGS__HTTP_TIMEOUT_SEC`) - The HTTP timeout (in seconds)
+  for the underlying HTTP client of the Remote Settings client.
+
 ### Location
 
 Configuration for determining the location of users.

--- a/merino-adm/src/remote_settings/mod.rs
+++ b/merino-adm/src/remote_settings/mod.rs
@@ -92,9 +92,10 @@ impl RemoteSettingsSuggester {
         settings: &RemoteSettingsGlobalSettings,
         config: &RemoteSettingsConfig,
     ) -> Result<remote_settings_client::Client, SetupError> {
-        let reqwest_client = ReqwestClient::try_new(settings.http_timeout)
-            .context("Unable to create the Reqwest client")
-            .map_err(SetupError::Network)?;
+        let reqwest_client =
+            ReqwestClient::try_new(settings.http_request_timeout, settings.http_connect_timeout)
+                .context("Unable to create the Reqwest client")
+                .map_err(SetupError::Network)?;
         let client = remote_settings_client::Client::builder()
             .bucket_name(
                 config

--- a/merino-adm/src/remote_settings/mod.rs
+++ b/merino-adm/src/remote_settings/mod.rs
@@ -92,7 +92,7 @@ impl RemoteSettingsSuggester {
         settings: &RemoteSettingsGlobalSettings,
         config: &RemoteSettingsConfig,
     ) -> Result<remote_settings_client::Client, SetupError> {
-        let reqwest_client = ReqwestClient::try_new()
+        let reqwest_client = ReqwestClient::try_new(settings.http_timeout)
             .context("Unable to create the Reqwest client")
             .map_err(SetupError::Network)?;
         let client = remote_settings_client::Client::builder()

--- a/merino-adm/src/remote_settings/reqwest_client.rs
+++ b/merino-adm/src/remote_settings/reqwest_client.rs
@@ -11,23 +11,29 @@ use remote_settings_client::client::net::{
     Url as RsUrl,
 };
 use reqwest::{header::CONTENT_TYPE, Method, Response};
+use std::time::Duration;
 
 /// An remote-settings-client HTTP client that uses Reqwest.
 #[derive(Debug)]
 pub struct ReqwestClient {
     /// The client that will be used to make http requests.
     reqwest_client: reqwest::Client,
+    /// The HTTP timeout in seconds.
+    http_timeout: Duration,
 }
 
 impl ReqwestClient {
     /// Instantiate a new Reqwest client to perform HTTP requests.
-    pub fn try_new() -> Result<ReqwestClient, Error> {
+    pub fn try_new(http_timeout: Duration) -> Result<ReqwestClient, Error> {
         let reqwest_client = reqwest::Client::builder()
             // Disable the connection pool to avoid the IncompleteMessage errors.
             // See #259 for more details.
             .pool_max_idle_per_host(0)
             .build()?;
-        Ok(Self { reqwest_client })
+        Ok(Self {
+            reqwest_client,
+            http_timeout,
+        })
     }
 }
 
@@ -66,7 +72,7 @@ impl RsRequester for ReqwestClient {
             .header(CONTENT_TYPE, "application/json")
             .headers(headers)
             .body(data)
-            .timeout(std::time::Duration::from_secs(3))
+            .timeout(self.http_timeout)
             .send()
             .await
             .and_then(Response::error_for_status)

--- a/merino-settings/src/lib.rs
+++ b/merino-settings/src/lib.rs
@@ -193,6 +193,12 @@ pub struct RemoteSettingsGlobalSettings {
     /// by the provider.
     pub default_collection: String,
 
+    /// The HTTP timeout (in seconds) for the underlying client of the Remote Settings client:
+    /// [`ReqwestClient`](merino-adm::reqwest_client::ReqwestClient).
+    #[serde_as(as = "DurationSeconds")]
+    #[serde(rename = "http_timeout_sec")]
+    pub http_timeout: Duration,
+
     /// The interval (in seconds) of the Remote Settings cron job. This should
     /// be set smaller than `RemoteSettingsConfig::resync_interval`.
     #[serde_as(as = "DurationSeconds")]

--- a/merino-settings/src/lib.rs
+++ b/merino-settings/src/lib.rs
@@ -193,11 +193,17 @@ pub struct RemoteSettingsGlobalSettings {
     /// by the provider.
     pub default_collection: String,
 
-    /// The HTTP timeout (in seconds) for the underlying client of the Remote Settings client:
+    /// The HTTP request timeout (in seconds) for the underlying client of the Remote Settings client:
     /// [`ReqwestClient`](merino-adm::reqwest_client::ReqwestClient).
     #[serde_as(as = "DurationSeconds")]
-    #[serde(rename = "http_timeout_sec")]
-    pub http_timeout: Duration,
+    #[serde(rename = "http_request_timeout_sec")]
+    pub http_request_timeout: Duration,
+
+    /// The HTTP connect timeout (in seconds) for the underlying client of the Remote Settings client:
+    /// [`ReqwestClient`](merino-adm::reqwest_client::ReqwestClient).
+    #[serde_as(as = "DurationSeconds")]
+    #[serde(rename = "http_connect_timeout_sec")]
+    pub http_connect_timeout: Duration,
 
     /// The interval (in seconds) of the Remote Settings cron job. This should
     /// be set smaller than `RemoteSettingsConfig::resync_interval`.

--- a/test-engineering/contract-tests/docker-compose.yml
+++ b/test-engineering/contract-tests/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       MERINO__REMOTE_SETTINGS__CRON_INTERVAL_SEC: "1"
       MERINO__REMOTE_SETTINGS__DEFAULT_BUCKET: main
       MERINO__REMOTE_SETTINGS__DEFAULT_COLLECTION: quicksuggest
+      MERINO__REMOTE_SETTINGS__HTTP_TIMEOUT_SEC: "10"
       MERINO__REMOTE_SETTINGS__RESYNC_INTERVAL_SEC: "2"
       MERINO__REMOTE_SETTINGS__SERVER: http://kinto:8888
     depends_on:
@@ -42,7 +43,7 @@ services:
       KINTO_DATA_DIR: /tmp/kinto
       KINTO_ATTACHMENTS_URL: http://kinto-attachments:80
     command: >
-      /wait-for-it.sh merino:8000 --strict -- pytest -vv
+      /wait-for-it.sh -t 60 merino:8000 --strict -- pytest -vv
 
   kinto:
     image: mozilla/kinto-dist:25.0.0

--- a/test-engineering/contract-tests/docker-compose.yml
+++ b/test-engineering/contract-tests/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       KINTO_DATA_DIR: /tmp/kinto
       KINTO_ATTACHMENTS_URL: http://kinto-attachments:80
     command: >
-      /wait-for-it.sh -t 60 merino:8000 --strict -- pytest -vv
+      /wait-for-it.sh -t 45 merino:8000 --strict -- pytest -vv
 
   kinto:
     image: mozilla/kinto-dist:25.0.0


### PR DESCRIPTION
This makes the HTTP timeout configurable for `ReqwestClient` (the underlying client of Remote Settings). It allows us to fix the timeout issue that we're experiencing in docker on Apple M1 laptops.

This fixes [CONSVC-1894](https://mozilla-hub.atlassian.net/browse/CONSVC-1894).