### PR TITLE
test: clear records between scenario executions in contract tests [do not deploy]

### DIFF
--- a/test-engineering/contract-tests/client/README.md
+++ b/test-engineering/contract-tests/client/README.md
@@ -40,6 +40,8 @@ and steps.
   * `data_type` - Set to `data` or `offline-expansion-data`.
 * A Kinto service scenario step will not check a `response` defined in the scenario, 
   but will raise an error in the event of an unexpected HTTP response.
+* All records populated by Kinto service scenario steps are deleted as part of the 
+  scenario teardown.
 
 Example:
 ```yaml

--- a/test-engineering/contract-tests/client/tests/kinto.py
+++ b/test-engineering/contract-tests/client/tests/kinto.py
@@ -77,6 +77,19 @@ class KintoResponse(BaseModel):
     data: KintoResponseRecord
 
 
+def delete_records(environment: KintoEnvironment) -> None:
+    """Clear all record information from Kinto."""
+
+    url: str = (
+        f"{environment.server}/v1/"
+        f"buckets/{environment.bucket}/"
+        f"collections/{environment.collection}/"
+        f"records"
+    )
+    response: RequestsResponse = requests.delete(url)
+    response.raise_for_status()
+
+
 def get_record(environment: KintoEnvironment, record_id: str) -> KintoResponseRecord:
     """Get attachment information from Kinto for the given record ID."""
 

--- a/test-engineering/contract-tests/client/tests/test_merino.py
+++ b/test-engineering/contract-tests/client/tests/test_merino.py
@@ -9,7 +9,13 @@ import pytest
 import requests
 from requests import Response as RequestsResponse
 
-from kinto import KintoEnvironment, KintoRequestRecord, upload_attachment, upload_icons
+from kinto import (
+    KintoEnvironment,
+    KintoRequestRecord,
+    delete_records,
+    upload_attachment,
+    upload_icons,
+)
 from models import (
     KintoRequest,
     MerinoRequest,
@@ -185,6 +191,15 @@ def assert_200_response(
             expected_suggestion = expected_suggestions_by_id[suggestion_id(suggestion)]
             assert suggestion.icon == expected_suggestion.icon
             continue
+
+
+@pytest.fixture(scope="function", autouse=True)
+def fixture_function_teardown(kinto_environment: KintoEnvironment):
+    """Execute instructions after each test."""
+
+    yield  # Allow test to execute
+
+    delete_records(kinto_environment)
 
 
 def test_merino(steps: List[Step], step_functions: Dict[Service, Callable]):

--- a/test-engineering/contract-tests/volumes/client/scenarios.yml
+++ b/test-engineering/contract-tests/volumes/client/scenarios.yml
@@ -109,7 +109,7 @@ scenarios:
           filename: "data-02.json"
           data_type: "data"
       - request:
-          delay: 3 # Wait for remote settings data to load into merino
+          delay: 5 # Wait for remote settings data to load into merino
           service: merino
           method: GET
           path: '/api/v1/suggest?q=coffee'
@@ -150,7 +150,7 @@ scenarios:
           filename: "data-02.json"
           data_type: "data"
       - request:
-          delay: 3  # Wait for remote settings data to load into merino
+          delay: 5  # Wait for remote settings data to load into merino
           service: merino
           method: GET
           path: '/api/v1/suggest?q=banana'
@@ -205,7 +205,7 @@ scenarios:
           filename: "offline-expansion-data-01.json"
           data_type: "offline-expansion-data"
       - request:
-          delay: 3 # Wait for remote settings data to load into merino
+          delay: 5 # Wait for remote settings data to load into merino
           service: merino
           method: GET
           path: '/api/v1/suggest?q=orange'


### PR DESCRIPTION
## Description
* add teardown fixture in merino contract tests
* add delete records function to kinto module
* increase delay in contract test scenarios to assure remote settings resync in merino
* update README

⚠️ **Note**: These changes are identical to https://github.com/mozilla-services/merino-py/pull/43

## Issue(s)
[CONSVC-1840](https://mozilla-hub.atlassian.net/browse/CONSVC-1840)